### PR TITLE
Fix symbols for kilobyte (according to Wikipedia page)

### DIFF
--- a/quantulum3/units.json
+++ b/quantulum3/units.json
@@ -3048,9 +3048,7 @@
     "URI": "https://en.wikipedia.org/wiki/Kilobyte",
     "dimensions": [],
     "symbols": [
-      "kB",
-      "K",
-      "KB"
+      "kB"
     ]
   },
   {
@@ -3150,7 +3148,9 @@
     "URI": "https://en.wikipedia.org/wiki/Kibibyte",
     "dimensions": [],
     "symbols": [
-      "KiB"
+      "KiB",
+      "K",
+      "KB"
     ]
   },
   {


### PR DESCRIPTION
**Fixed issues:** 
"K" and "KB" were wrongly interpreted as symbols for 1000 bytes while they actually are more often used for 1024 bytes (one kibibyte)

**Included changes:**

See above

**Breaking changes:**

None