### PR TITLE
Fix errors with combined spelled out/digit values

### DIFF
--- a/quantulum3/regex.py
+++ b/quantulum3/regex.py
@@ -181,7 +181,8 @@ TXT_PATTERN = r'''            # Pattern for extracting mixed digit-spelled num
     [ -]?(?:%s)
     [ -]?(?:%s)?[ -]?(?:%s)?[ -]?(?:%s)?
     [ -]?(?:%s)?[ -]?(?:%s)?[ -]?(?:%s)?
-''' % tuple([NUM_PATTERN] + 7 * [ALL_NUM])
+    (?!\s?%s)                    # Disallow being followed by only a number
+''' % tuple([NUM_PATTERN] + 7 * [ALL_NUM] + [NUM_PATTERN])
 
 REG_TXT = re.compile(TXT_PATTERN, re.VERBOSE | re.IGNORECASE)
 

--- a/quantulum3/tests/quantities.json
+++ b/quantulum3/tests/quantities.json
@@ -1061,5 +1061,31 @@
         "uncertainty": null
       }
     ]
+  },
+  {
+    "req": "Look there! This is a 5 metre shark!",
+    "res": [
+      {
+        "value": 5.0,
+        "unit": "metre",
+        "surface": "5 metre",
+        "entity": "length",
+        "dimensions": [],
+        "uncertainty": null
+      }
+    ]
+  },
+  {
+    "req": "A mouse can get through a 1/4 inch gap",
+    "res": [
+      {
+        "value": 0.25,
+        "unit": "inch",
+        "surface": "1/4 inch",
+        "entity": "length",
+        "dimensions": [],
+        "uncertainty": null
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Simply disallow spellout values followed by normal numbers
Thus "a ..." and "and ..." is fixed

**Fixed issues:** 
#1 
#90 


**Included changes:**
Disallow digit numbers after spelled out numbers (spelled out numbers will be ignored, but this is so rarely meaningful that it mostly fixes errors)

**Breaking changes:**
