### PR TITLE
quantulum3 not supported on Mac OS due to os.sched_getaffinity() not being supported.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,6 @@ stemming = "*"
 num2words = "*"
 joblib = "*"
 psutil = "*"
-e1839a8 = {editable = true,path = "."}
 
 [dev-packages]
 yapf = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,8 @@ wikipedia = "*"
 stemming = "*"
 num2words = "*"
 joblib = "*"
+psutil = "*"
+e1839a8 = {editable = true,path = "."}
 
 [dev-packages]
 yapf = "*"

--- a/quantulum3/classifier.py
+++ b/quantulum3/classifier.py
@@ -9,6 +9,7 @@ import logging
 import pkg_resources
 import os
 import multiprocessing
+import psutil
 
 # Semi-dependencies
 try:
@@ -133,7 +134,7 @@ def train_classifier(parameters=None,
     if n_jobs is None:
         try:
             # Retreive the number of cpus that can be used
-            n_jobs = len(os.sched_getaffinity(0))
+            n_jobs = psutil.cpu_count()
         except AttributeError:
             # n_jobs stays None such that Pool will try to
             # automatically set the number of processes appropriately


### PR DESCRIPTION
os.sched_getaffinity is not supported on MacOS, so I added the psutil module to the Pipfile and replaced the method for getting the cpu_count  to psutil.cpu_count(), as it seems to give back accurate numbers for virtual cores. I have checked that this result is accurate on Windows 10, Arch Linux and Mac OS.

There was one method available in the subprocessing library which gave you the cpu count, but I have read that this can give incorrect results on some linux machines (CentOS).

Thanks, Michael
