### PR TITLE
pm/am correction

### DIFF
--- a/quantulum3/_lang/en_US/parser.py
+++ b/quantulum3/_lang/en_US/parser.py
@@ -181,6 +181,16 @@ def build_quantity(orig_text, text, item, values, unit, surface, span, uncert):
         span = (span[0], span[1] - 1)
         _LOGGER.debug('\tCorrect for "1990s" pattern')
 
+    # Usually "1am", "5.12 pm" stand for the time, not pico- or attometer
+    if (
+            len(unit.dimensions) == 1 and
+            ("pm" == item['unit1'] or "am" == item['unit1']) and
+            unit.entity.name == "length" and
+            re.fullmatch(r"\d(\.\d\d)?", item['value'])
+    ):
+        _LOGGER.debug('\tCorrect for am/pm time pattern')
+        return
+
     # check if a unit without operators, actually is a common word
     if unit.original_dimensions:
 
@@ -196,9 +206,9 @@ def build_quantity(orig_text, text, item, values, unit, surface, span, uncert):
         candidates = [u['power'] == 1 for u in unit.original_dimensions]
         for start in range(0, len(unit.original_dimensions)):
             for end in reversed(
-                    range(start + 1,
-                          len(unit.original_dimensions) + 1)):
-                # Try to match a combination of consecutive surfaces with a
+                    range(start + 2,
+                          len(unit.original_dimensions)+1)):
+                # Try to match a combination of >1 consecutive surfaces with a
                 # common 4 letter word
                 if not all(candidates[start:end]):
                     continue

--- a/quantulum3/_lang/en_US/parser.py
+++ b/quantulum3/_lang/en_US/parser.py
@@ -184,9 +184,9 @@ def build_quantity(orig_text, text, item, values, unit, surface, span, uncert):
     # Usually "1am", "5.12 pm" stand for the time, not pico- or attometer
     if (
             len(unit.dimensions) == 1 and
-            ("pm" == item['unit1'] or "am" == item['unit1']) and
+            ("pm" == item.group('unit1') or "am" == item.group('unit1')) and
             unit.entity.name == "length" and
-            re.fullmatch(r"\d(\.\d\d)?", item['value'])
+            re.fullmatch(r"\d(\.\d\d)?", item.group('value'))
     ):
         _LOGGER.debug('\tCorrect for am/pm time pattern')
         return

--- a/quantulum3/_lang/en_US/tests/quantities.json
+++ b/quantulum3/_lang/en_US/tests/quantities.json
@@ -1170,5 +1170,53 @@
         "uncertainty": null
       }
     ]
+  },
+  {
+    "req": "At 2 pm everybody will be gone.",
+    "res": []
+  },
+  {
+    "req": "This nano grid has a size of 2.1 pm.",
+    "res": [
+      {
+        "value": 2.1,
+        "unit": "picometre",
+        "surface": "2.1 pm",
+        "entity": "length",
+        "uncertainty": null
+      }
+    ]
+  },
+  {
+    "req": "This nano grid has a size of 2.123 pm.",
+    "res": [
+      {
+        "value": 2.123,
+        "unit": "picometre",
+        "surface": "2.123 pm",
+        "entity": "length",
+        "uncertainty": null
+      }
+    ]
+  },
+  {
+    "req": "This nano grid has a size of 2.123 am.",
+    "res": [
+      {
+        "value": 2.123,
+        "unit": "attometre",
+        "surface": "2.123 am",
+        "entity": "length",
+        "uncertainty": null
+      }
+    ]
+  },
+  {
+    "req": "I arrived at 2.13 am.",
+    "res": []
+  },
+  {
+    "req": "The bank robbery begun at 2pm and was over until 2.17pm.",
+    "res": []
   }
 ]

--- a/quantulum3/parser.py
+++ b/quantulum3/parser.py
@@ -427,8 +427,8 @@ def parse(text, lang='en_US', verbose=False):
     logging.basicConfig(format=log_format)
 
     if verbose:  # pragma: no cover
-        prev_level = _LOGGER.getEffectiveLevel()
-        _LOGGER.setLevel(logging.DEBUG)
+        prev_level = logging.root.getEffectiveLevel()
+        logging.root.setLevel(logging.DEBUG)
         _LOGGER.debug('Verbose mode')
 
     orig_text = text
@@ -459,7 +459,7 @@ def parse(text, lang='en_US', verbose=False):
             _LOGGER.debug('Could not parse quantity: %s', err)
 
     if verbose:  # pragma: no cover
-        _LOGGER.setLevel(prev_level)
+        logging.root.setLevel(prev_level)
 
     return quantities
 

--- a/quantulum3/tests/test_no_classifier.py
+++ b/quantulum3/tests/test_no_classifier.py
@@ -41,7 +41,7 @@ class ParsingTest(unittest.TestCase):
                 'got {}: {}, {}'.format(
                     len(test['res']), len(quants), test['res'], quants))
             for index, quant in enumerate(quants):
-                self.assertEqual(quant, test['res'][index])
+                self.assertEqual(test['res'][index], quant)
 
         classifier_tests = load_quantity_tests(True, lang)
         correct = 0

--- a/quantulum3/tests/test_setup.py
+++ b/quantulum3/tests/test_setup.py
@@ -78,8 +78,8 @@ def add_type_equalities(testcase):
                     secondval = getattr(second, diff)
                     if firstval != secondval:
                         msg = ('Quantities {first} and {second} are differing '
-                               'in attribute "{attribute}:'
-                               '{firstval}" != "{secondval}')
+                               'in attribute "{attribute}":'
+                               '{firstval} != {secondval}')
                         msg = msg.format(
                             attribute=diff,
                             firstval=firstval,

--- a/quantulum3/units.json
+++ b/quantulum3/units.json
@@ -194,85 +194,8 @@
     "dimensions": [],
     "symbols": [
       "m"
-    ]
-  },
-  {
-    "name": "exametre",
-    "surfaces": [
-      "exametre",
-      "exameter"
     ],
-    "entity": "length",
-    "URI": "1_exametre",
-    "dimensions": [],
-    "symbols": [
-      "Em"
-    ]
-  },
-  {
-    "name": "petametre",
-    "surfaces": [
-      "petametre",
-      "petameter"
-    ],
-    "entity": "length",
-    "URI": "1_petametre",
-    "dimensions": [],
-    "symbols": [
-      "Pm"
-    ]
-  },
-  {
-    "name": "terametre",
-    "surfaces": [
-      "terametre",
-      "terameter"
-    ],
-    "entity": "length",
-    "URI": "1_terametre",
-    "dimensions": [],
-    "symbols": [
-      "Tm"
-    ]
-  },
-  {
-    "name": "gigametre",
-    "surfaces": [
-      "gigametre",
-      "gigameter"
-    ],
-    "entity": "length",
-    "URI": "Gigametre",
-    "dimensions": [],
-    "symbols": [
-      "Gm"
-    ]
-  },
-  {
-    "name": "megametre",
-    "surfaces": [
-      "megametre",
-      "megameter"
-    ],
-    "entity": "length",
-    "URI": "Megametre",
-    "dimensions": [],
-    "symbols": [
-      "Mm"
-    ]
-  },
-  {
-    "name": "kilometre",
-    "surfaces": [
-      "kilometre",
-      "kilometer"
-    ],
-    "entity": "length",
-    "URI": "Kilometre",
-    "dimensions": [],
-    "symbols": [
-      "km"
-    ]
+    "prefixes": ["E", "P", "T", "G", "M", "k", "m", "n", "p", "f", "a", "z", "y"]
   },
   {
     "name": "hectometre",
@@ -331,19 +254,6 @@
     ]
   },
   {
-    "name": "millimetre",
-    "surfaces": [
-      "millimetre",
-      "millimeter"
-    ],
-    "entity": "length",
-    "URI": "Millimetre",
-    "dimensions": [],
-    "symbols": [
-      "mm"
-    ]
-  },
-  {
     "name": "micrometre",
     "surfaces": [
       "micrometre",
@@ -355,45 +265,6 @@
     "dimensions": [],
     "symbols": [
       "µm"
-    ]
-  },
-  {
-    "name": "nanometre",
-    "surfaces": [
-      "nanometre",
-      "nanometer"
-    ],
-    "entity": "length",
-    "URI": "Nanometre",
-    "dimensions": [],
-    "symbols": [
-      "nm"
-    ]
-  },
-  {
-    "name": "picometre",
-    "surfaces": [
-      "picometre",
-      "picometer"
-    ],
-    "entity": "length",
-    "URI": "Picometre",
-    "dimensions": [],
-    "symbols": [
-      "pm"
-    ]
-  },
-  {
-    "name": "femtometre",
-    "surfaces": [
-      "femtometre",
-      "femtometer"
-    ],
-    "entity": "length",
-    "URI": "Femtometre",
-    "dimensions": [],
-    "symbols": [
-      "fm"
     ]
   },
   {


### PR DESCRIPTION
**Fixed issues:** 
partly #135 

**Included changes:**
throws away units that are parsed from `\d(.\d\d)?\s?(am|pm)`

**Breaking changes:**
attometre and picometre texts with none or 2 digits of precision are treated as time and thrown away