### PR TITLE
Expand spelled number recognition

### DIFF
--- a/quantulum3/_lang/en_US/parser.py
+++ b/quantulum3/_lang/en_US/parser.py
@@ -272,19 +272,8 @@ def build_quantity(orig_text, text, item, values, unit, surface, span, uncert):
                 # Combination has to be at least one letter
                 if len(combination) < 1:
                     continue
-                # Combination has to be all lower or capitalized in the first
-                # or all letters
-                if not (
-                    combination.islower()
-                    or (
-                        len(combination) > 2
-                        and (
-                            (combination[0].isupper() and combination[1:].islower())
-                            or combination.isupper()
-                        )
-                    )
-                ):
-                    continue
+                # Combination may have any capitalization due to possible common names
+                # i.e. PayPal, iPhone, LaTeX
                 # Combination has to be inside the surface
                 if combination not in surface:
                     continue

--- a/quantulum3/_lang/en_US/parser.py
+++ b/quantulum3/_lang/en_US/parser.py
@@ -62,13 +62,13 @@ def extract_spellout_values(text):
     """
 
     values = []
-    try:
-        for item in reg.text_pattern_reg(lang).finditer(text):
+    for item in reg.text_pattern_reg(lang).finditer(text):
+        try:
             surface, span = clean_surface(item.group(0), item.span())
             if not surface or surface.lower() in reg.scales(lang):
                 continue
             curr = result = 0.0
-            for word in surface.split():
+            for word in re.finditer(reg.numberwords_regex(), surface):
                 try:
                     scale, increment = (
                         1,
@@ -76,12 +76,12 @@ def extract_spellout_values(text):
                             re.sub(
                                 r"(-$|[%s])" % reg.grouping_operators_regex(lang),
                                 "",
-                                word.lower(),
+                                word[0].lower(),
                             )
                         ),
                     )
                 except ValueError:
-                    scale, increment = reg.numberwords(lang)[word.lower()]
+                    scale, increment = reg.numberwords(lang)[word[0].lower()]
                 curr = curr * scale + increment
                 if scale > 100:
                     result += curr
@@ -93,9 +93,9 @@ def extract_spellout_values(text):
                     "new_surface": str(result + curr),
                 }
             )
-    except KeyError:
-        # just ignore the match if an error occurred
-        values = []
+        except KeyError:
+            # just ignore the match if an error occurred
+            values = []
 
     return sorted(values, key=lambda x: x["old_span"][0])
 

--- a/quantulum3/_lang/en_US/regex.py
+++ b/quantulum3/_lang/en_US/regex.py
@@ -54,7 +54,7 @@ DECIMALS = {
     "ninth": 1 / 9,
 }
 
-MISCNUM = {"and": (1, 0), "a": (1, 1), "an": (1, 1)}
+MISCNUM = {"&": (1, 0), "and": (1, 0), "a": (1, 1), "an": (1, 1)}
 
 ###############################################################################
 
@@ -75,8 +75,10 @@ TEXT_PATTERN = r"""            # Pattern for extracting mixed digit-spelled num
     )?
     [ -]?(?:{numberwords_regex})
     [ -]?(?:{numberwords_regex})?
-    [ -]?(?:{numberwords_regex})?[ -]?(?:{numberwords_regex})?
-    [ -]?(?:{numberwords_regex})?[ -]?(?:{numberwords_regex})?
+    [ -]?(?:{numberwords_regex})?
+    [ -]?(?:{numberwords_regex})?
+    [ -]?(?:{numberwords_regex})?
+    [ -]?(?:{numberwords_regex})?
     [ -]?(?:{numberwords_regex})?
     (?!\s?{number_pattern_no_groups}) # Disallow being followed by only a
                                       # number

--- a/quantulum3/_lang/en_US/regex.py
+++ b/quantulum3/_lang/en_US/regex.py
@@ -73,13 +73,7 @@ TEXT_PATTERN = r"""            # Pattern for extracting mixed digit-spelled num
         (?<![a-zA-Z0-9+.-])    # lookbehind, avoid "Area51"
         {number_pattern_no_groups}
     )?
-    [ -]?(?:{numberwords_regex})
-    [ -]?(?:{numberwords_regex})?
-    [ -]?(?:{numberwords_regex})?
-    [ -]?(?:{numberwords_regex})?
-    [ -]?(?:{numberwords_regex})?
-    [ -]?(?:{numberwords_regex})?
-    [ -]?(?:{numberwords_regex})?
+    (?:[, -]*(?:{numberwords_regex}))+
     (?!\s?{number_pattern_no_groups}) # Disallow being followed by only a
                                       # number
 """

--- a/quantulum3/_lang/en_US/tests/quantities.json
+++ b/quantulum3/_lang/en_US/tests/quantities.json
@@ -1347,5 +1347,9 @@
         "uncertainty": null
       }
     ]
+  },
+  {
+    "req": "I sent some money using a PayPal account",
+    "res": []
   }
 ]

--- a/quantulum3/regex.py
+++ b/quantulum3/regex.py
@@ -90,7 +90,9 @@ def numberwords(lang="en_US"):
 
 @cached
 def numberwords_regex(lang="en_US"):
-    all_numbers = r"|".join(r"\b%s\b" % i for i in list(numberwords(lang).keys()) if i)
+    all_numbers = r"|".join(
+        r"((?<=\W)|^)%s((?=\W)|$)" % i for i in list(numberwords(lang).keys()) if i
+    )
     return all_numbers
 
 


### PR DESCRIPTION
fixes one issue mentioned in #134 specifically recognizing "," and "&" in spelled number combinations