### PR TITLE
Add example of accessing parsed numerical values and unit names to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ u'2 liters'
 (7, 15)
 ```
 
-The *value* attibute provides the parsed numeric value and the *unit.name*
+The *value* attribute provides the parsed numeric value and the *unit.name*
 attribute provides the name of the parsed unit:
 
 ```pycon

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ u'2 liters'
 (7, 15)
 ```
 
+The *value* attibute provides the parsed numeric value and the *unit.name*
+attribute provides the name of the parsed unit:
+
+```pycon
+>>> quants[0].value
+2.0
+>>> quants[0].unit.name
+'litre'
+```
+
 An inline parser that embeds the parsed quantities in the text is also
 available (especially useful for debugging):
 


### PR DESCRIPTION
Thanks for this great library!

This sounds silly, but everyone I've introduced to this library has gotten stuck figuring out how to access the parsed numerical amount and the parsed name of the unit. The only way to figure it out is to go digging in the code, but this is a common thing that many new users want to do with this library when they are first exploring it. It seems like something that should be front and center in the README.

This adds two lines to the README that should hopefully clarify this for new users. Feel free to ignore this if you disagree, but hopefully this is helpful.