### PR TITLE
Fix some bugs in converting spelled-out numbers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,9 @@ script:
   - coverage run -a --source=quantulum3 setup.py test -s quantulum3.tests.test_setup
   # Test whether quantulum works without classifier
   - coverage run -a --source=quantulum3 setup.py test -s quantulum3.tests.test_no_classifier
-  # Test requirements.txt
+  # Test language specific non-classifier tasks
+  - coverage run -a --source=quantulum3 setup.py test -s quantulum3._lang.en_US.tests.extract_spellout_values
+  # Test requirements.txt for classifier requirements
   - pip install -r requirements_classifier.txt
   # Lint package, now that all requirements are installed
   - pylint quantulum3
@@ -39,7 +41,6 @@ script:
   # Note that the classifier trained here is included in the target package
   - coverage run -a --source=quantulum3 setup.py test -s quantulum3.tests.test_classifier.ClassifierBuild
   - coverage run -a --source=quantulum3 setup.py test -s quantulum3.tests.test_classifier.ClassifierTest
-  - coverage run -a --source=quantulum3 setup.py test -s quantulum3._lang.en_US.tests.extract_spellout_values
 
 after_success:
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ script:
   # Note that the classifier trained here is included in the target package
   - coverage run -a --source=quantulum3 setup.py test -s quantulum3.tests.test_classifier.ClassifierBuild
   - coverage run -a --source=quantulum3 setup.py test -s quantulum3.tests.test_classifier.ClassifierTest
+  - coverage run -a --source=quantulum3 setup.py test -s quantulum3._lang.en_US.tests.extract_spellout_values
 
 after_success:
   - coverage report

--- a/quantulum3/_lang/en_US/parser.py
+++ b/quantulum3/_lang/en_US/parser.py
@@ -71,6 +71,7 @@ def split_spellout_sequence(text, span):
     prev_word_rank = 0
     prev_scale = 0
     last_word_end = last_span_start = 0
+    prev_word = ""
     for word_span in re.finditer(r"\w+", text):
         word = word_span.group(0)
         rank = (
@@ -98,15 +99,23 @@ def split_spellout_sequence(text, span):
             prev_scale = rank
         if should_split:
             # yield up to here
+            adjust = 0
+            if prev_word.lower() in [
+                "and",
+                "&",
+            ]:  # don't include the conjunction in the yield
+                adjust = -(len(prev_word) + 1)
             yield (
-                text[last_span_start:last_word_end],
-                (last_span_start + start_offset, last_word_end + start_offset),
+                text[last_span_start : last_word_end + adjust],
+                (last_span_start + start_offset, last_word_end + start_offset + adjust),
             )
             last_span_start = word_span.span()[0]
         # update the state
         if rank >= 3:
             prev_scale = rank
-        prev_word_rank = rank
+        if word.lower() not in ["and", "&"]:
+            prev_word_rank = rank
+        prev_word = word
         last_word_end = word_span.span()[1]
     # yield the last item
     yield (

--- a/quantulum3/_lang/en_US/parser.py
+++ b/quantulum3/_lang/en_US/parser.py
@@ -54,6 +54,10 @@ def clean_surface(surface, span):
 
     return surface, span
 
+###############################################################################
+def word_before_span(text, span):
+    if span[0] == 0: return ""
+    return text[:span[0]].split()[-1]
 
 ###############################################################################
 def extract_spellout_values(text):
@@ -62,6 +66,10 @@ def extract_spellout_values(text):
     """
     values = []
     for item in reg.text_pattern_reg(lang).finditer(text):
+        # don't allow "seveal hundred", "couple thousand", "some million years ago"
+        # TODO maybe allow "several [scale]", "couple [scale]" and treat as a range?
+        if word_before_span(text, item.span()).lower() in ["several", "couple", "some"]:
+          continue
         try:
             surface, span = clean_surface(item.group(0), item.span())
             if not surface:  # or surface.lower() in reg.scales(lang):
@@ -83,7 +91,7 @@ def extract_spellout_values(text):
                     match = re.search(reg.numberwords_regex(), word)
                     scale, increment = reg.numberwords(lang)[match.group(0)]
                 if (
-                    scale > 0 and increment == 0 and curr == 0.0 and result == 0.0
+                    scale > 0 and increment == 0 and curr == 0.0 and result == 0.0 and word != "zero"
                 ):  # "million" in the beginning
                     increment = scale
                     scale = 0.0

--- a/quantulum3/_lang/en_US/parser.py
+++ b/quantulum3/_lang/en_US/parser.py
@@ -54,10 +54,13 @@ def clean_surface(surface, span):
 
     return surface, span
 
+
 ###############################################################################
 def word_before_span(text, span):
-    if span[0] == 0: return ""
-    return text[:span[0]].split()[-1]
+    if span[0] == 0:
+        return ""
+    return text[: span[0]].split()[-1]
+
 
 ###############################################################################
 def extract_spellout_values(text):
@@ -69,7 +72,7 @@ def extract_spellout_values(text):
         # don't allow "seveal hundred", "couple thousand", "some million years ago"
         # TODO maybe allow "several [scale]", "couple [scale]" and treat as a range?
         if word_before_span(text, item.span()).lower() in ["several", "couple", "some"]:
-          continue
+            continue
         try:
             surface, span = clean_surface(item.group(0), item.span())
             if not surface:  # or surface.lower() in reg.scales(lang):
@@ -91,7 +94,11 @@ def extract_spellout_values(text):
                     match = re.search(reg.numberwords_regex(), word)
                     scale, increment = reg.numberwords(lang)[match.group(0)]
                 if (
-                    scale > 0 and increment == 0 and curr == 0.0 and result == 0.0 and word != "zero"
+                    scale > 0
+                    and increment == 0
+                    and curr == 0.0
+                    and result == 0.0
+                    and word != "zero"
                 ):  # "million" in the beginning
                     increment = scale
                     scale = 0.0

--- a/quantulum3/_lang/en_US/parser.py
+++ b/quantulum3/_lang/en_US/parser.py
@@ -59,7 +59,44 @@ def clean_surface(surface, span):
 def word_before_span(text, span):
     if span[0] == 0:
         return ""
-    return text[: span[0]].split()[-1]
+    return text[:span[0]].split()[-1]
+
+###############################################################################
+def split_spellout_sequence(text, span):
+    units = reg.units(lang)
+    tens = reg.tens(lang)
+    scales = reg.scales(lang)
+    start_offset = span[0]
+    prev_word_rank = 0
+    prev_scale = 0
+    last_word_end = last_span_start = 0
+    for word_span in re.finditer(r"\w+", text):
+        word = word_span.group(0)
+        rank = 1 if word in units else 2 if word in tens else 3 + scales.index(word) if word in scales else 0
+        # if should start a new seqquence
+        # split on:
+        #   unit -> unit (one two three)
+        #   unit -> tens (five twenty)
+        #   tens -> tens (twenty thirty)
+        #   same scale starts  (hundred and one hundred and two)
+        should_split = False
+        if (prev_word_rank == 1 and rank in [1,2]):
+            should_split = True
+        elif (prev_word_rank == 2 and rank == 2):
+            should_split = True
+        elif rank >= 3 and rank == prev_scale:
+            should_split = True
+            prev_scale = rank
+        if should_split:
+            # yield up to here
+            yield (text[last_span_start:last_word_end], (last_span_start + start_offset, last_word_end + start_offset))
+            last_span_start = word_span.span()[0]
+        # update the state
+        if rank >= 3: prev_scale = rank
+        prev_word_rank = rank
+        last_word_end = word_span.span()[1]
+    # yield the last item
+    yield (text[last_span_start:], (last_span_start + start_offset, len(text) + start_offset))
 
 
 ###############################################################################
@@ -68,13 +105,18 @@ def extract_spellout_values(text):
     Convert spelled out numbers in a given text to digits.
     """
     values = []
-    for item in reg.text_pattern_reg(lang).finditer(text):
+    number_candidates = []
+    for range in reg.text_pattern_reg(lang).finditer(text):
+      for seq, span in split_spellout_sequence(range.group(0), range.span()):
+        number_candidates.append((seq, span))
+
+    for (seq, span) in number_candidates:
         # don't allow "seveal hundred", "couple thousand", "some million years ago"
         # TODO maybe allow "several [scale]", "couple [scale]" and treat as a range?
-        if word_before_span(text, item.span()).lower() in ["several", "couple", "some"]:
+        if word_before_span(text, span).lower() in ["several", "couple", "some"]:
             continue
         try:
-            surface, span = clean_surface(item.group(0), item.span())
+            surface, span = clean_surface(seq, span)
             if not surface:  # or surface.lower() in reg.scales(lang):
                 continue
             curr = result = 0.0

--- a/quantulum3/_lang/en_US/parser.py
+++ b/quantulum3/_lang/en_US/parser.py
@@ -142,7 +142,7 @@ def extract_spellout_values(text):
             continue
         try:
             surface, span = clean_surface(seq, span)
-            if not surface:  # or surface.lower() in reg.scales(lang):
+            if not surface:
                 continue
             curr = result = 0.0
             for word in surface.lower().split():

--- a/quantulum3/_lang/en_US/parser.py
+++ b/quantulum3/_lang/en_US/parser.py
@@ -56,47 +56,66 @@ def clean_surface(surface, span):
 
 
 ###############################################################################
+def split_spellout_sequence(text, span):
+    print("text:", text, "span:", span)
+    return [(text, span)]
+
 def extract_spellout_values(text):
     """
     Convert spelled out numbers in a given text to digits.
     """
-
     values = []
-    for item in reg.text_pattern_reg(lang).finditer(text):
-        try:
-            surface, span = clean_surface(item.group(0), item.span())
-            if not surface or surface.lower() in reg.scales(lang):
-                continue
-            curr = result = 0.0
-            for word in surface.lower().split():
-                try:
-                    scale, increment = (
-                        1,
-                        float(
-                            re.sub(
-                                r"(-$|[%s])" % reg.grouping_operators_regex(lang),
-                                "",
-                                word,
-                            )
-                        ),
-                    )
-                except ValueError:
-                    match = re.search(reg.numberwords_regex(), word)
-                    scale, increment = reg.numberwords(lang)[match.group(0)]
-                curr = curr * scale + increment
-                if scale > 100 or word == "and":
-                    result += curr
-                    curr = 0.0
-            values.append(
-                {
-                    "old_surface": surface,
-                    "old_span": span,
-                    "new_surface": str(result + curr),
-                }
-            )
-        except (KeyError, AttributeError):
-            # just ignore the match if an error occurred
-            pass
+    items = reg.text_pattern_reg(lang).finditer(text)
+    for item in items:
+        for (text, span) in split_spellout_sequence(item.group(0), item.span()):
+            print("item", item)
+            try:
+                surface, span = clean_surface(item.group(0), item.span())
+                print("clean:",surface, span)
+                if not surface: # or surface.lower() in reg.scales(lang):
+                    print("skipping", surface, "scales", reg.scales(lang))
+                    continue
+                curr = result = 0.0
+                for word in surface.lower().split():
+                    try:
+                        scale, increment = (
+                            1,
+                            float(
+                                re.sub(
+                                    r"(-$|[%s])" % reg.grouping_operators_regex(lang),
+                                    "",
+                                    word,
+                                )
+                            ),
+                        )
+                    except ValueError:
+                        match = re.search(reg.numberwords_regex(), word)
+                        scale, increment = reg.numberwords(lang)[match.group(0)]
+                    if (scale > 0 and increment == 0 and curr == 0.0 and result == 0.0): # "million" in the beginning
+                        increment = scale
+                        scale = 0.0
+                    # one hundred and five million --> curr 5.0 result 100.0 scale 1M increment 0
+                    # --> curr: 105, results: 0, scale 1M, increment 0
+                    if scale > result > 0:
+                      curr = curr + result
+                      result = 0.0
+                    print("curr", curr, "result", result, "scale", scale, "increment", increment)
+                    curr = curr * scale + increment
+                    print("curr", curr)
+                    if scale > 100 or word == "and":
+                        result += curr
+                        curr = 0.0
+                        print("result", result)
+                values.append(
+                    {
+                        "old_surface": surface,
+                        "old_span": span,
+                        "new_surface": str(result + curr),
+                    }
+                )
+            except (KeyError, AttributeError):
+                # just ignore the match if an error occurred
+                pass
 
     return sorted(values, key=lambda x: x["old_span"][0])
 

--- a/quantulum3/_lang/en_US/parser.py
+++ b/quantulum3/_lang/en_US/parser.py
@@ -64,7 +64,7 @@ def extract_spellout_values(text):
     for item in reg.text_pattern_reg(lang).finditer(text):
         try:
             surface, span = clean_surface(item.group(0), item.span())
-            if not surface: # or surface.lower() in reg.scales(lang):
+            if not surface:  # or surface.lower() in reg.scales(lang):
                 continue
             curr = result = 0.0
             for word in surface.lower().split():
@@ -82,14 +82,16 @@ def extract_spellout_values(text):
                 except ValueError:
                     match = re.search(reg.numberwords_regex(), word)
                     scale, increment = reg.numberwords(lang)[match.group(0)]
-                if (scale > 0 and increment == 0 and curr == 0.0 and result == 0.0): # "million" in the beginning
+                if (
+                    scale > 0 and increment == 0 and curr == 0.0 and result == 0.0
+                ):  # "million" in the beginning
                     increment = scale
                     scale = 0.0
                 # one hundred and five million --> curr 5.0 result 100.0 scale 1M increment 0
                 # --> curr: 105, results: 0, scale 1M, increment 0
                 if scale > result > 0:
-                  curr = curr + result
-                  result = 0.0
+                    curr = curr + result
+                    result = 0.0
                 curr = curr * scale + increment
                 if scale > 100 or word == "and":
                     result += curr

--- a/quantulum3/_lang/en_US/regex.py
+++ b/quantulum3/_lang/en_US/regex.py
@@ -62,7 +62,7 @@ SUFFIXES = {"k": 1e3, "K": 1e3, "M": 1e6, "B": 1e9, "T": 1e12}
 
 MULTIPLICATION_OPERATORS = {" times "}
 
-DIVISION_OPERATORS = {" per ", " a ", " / "}
+DIVISION_OPERATORS = {" per ", " a "}
 
 GROUPING_OPERATORS = {",", " "}
 DECIMAL_OPERATORS = {"."}

--- a/quantulum3/_lang/en_US/regex.py
+++ b/quantulum3/_lang/en_US/regex.py
@@ -62,7 +62,7 @@ SUFFIXES = {"k": 1e3, "K": 1e3, "M": 1e6, "B": 1e9, "T": 1e12}
 
 MULTIPLICATION_OPERATORS = {" times "}
 
-DIVISION_OPERATORS = {" per ", " a "}
+DIVISION_OPERATORS = {" per ", " a ", " / "}
 
 GROUPING_OPERATORS = {",", " "}
 DECIMAL_OPERATORS = {"."}

--- a/quantulum3/_lang/en_US/tests/extract_spellout_values.py
+++ b/quantulum3/_lang/en_US/tests/extract_spellout_values.py
@@ -1,22 +1,6 @@
 import unittest
-from ..parser import extract_spellout_values, split_spellout_sequence
+from ..parser import extract_spellout_values
 
-
-SPLIT_TEST_CASES = [
-  ("one two three", ["one", "two", "three"]),
-  ("one, two, three", ["one", "two", "three"]),
-  ("twenty five thirty six one hudred", ["twenty five", "thirty six", "one hundred"]),
-  ("hundred and five hundred and six", ["hundred and five", "hundred and six"]),
-  ("hundred and five twenty two", ["hundred and five", "twenty two"]),
-  ("hundred and five twenty two million", ["hundred and five", "twenty two million"]),
-]
-class SplitSpellout(unittest.TestCase):
-    def test_training(self, lang="en_US"):
-        """Test that classifier training works"""
-        for input, expected in SPLIT_TEST_CASES:
-          print("---------input", input)
-          output = [v[0] for v in split_spellout_sequence(input, (0,0))]
-          self.assertEquals(output, expected)
 
 TEST_CASES = [
   ("one hundred and five", ["105.0"]),
@@ -30,9 +14,9 @@ TEST_CASES = [
   ("two and a half", ["2.5"]),
   ("two and a half million", ["2500000.0"]),
   ("twenty six million and seventy two hundred", ["26007200.0"]),
-  #("a million and a half", ["1500000.0"]), # this is a hard one
   ("twenty", ["20.0"]),
-  #("twenty thirty fifty hundred", ["20.0", "30.0", "4000.0"]),
+  #("a million and a half", ["1500000.0"]), # this is a hard one
+  #("twenty thirty fifty hundred", ["20.0", "30.0", "5000.0"]),
   #("one, two, three", ["1.0", "2.0", "3.0"]),
 ]
 class ExtractSpellout(unittest.TestCase):

--- a/quantulum3/_lang/en_US/tests/extract_spellout_values.py
+++ b/quantulum3/_lang/en_US/tests/extract_spellout_values.py
@@ -22,6 +22,10 @@ TEST_CASES = [
     ## number splitting
     ("twenty thirty fifty hundred", ["20.0", "30.0", "5000.0"]),
     ("one, two, three", ["1.0", "2.0", "3.0"]),
+    ("one, two and three", ["1.0", "2.0", "3.0"]),
+    ("one and two and three", ["1.0", "2.0", "3.0"]),
+    ("one two and three", ["1.0", "2.0", "3.0"]),
+    ("twenty five and thirty six", ["25.0", "36.0"]),
     ("twenty five thirty six one hundred", ["25.0", "36.0", "100.0"]),
     ("hundred and five hundred and six", ["105.0", "106.0"]),  # this is ambiguous..
     ("hundred and five twenty two", ["105.0", "22.0"]),

--- a/quantulum3/_lang/en_US/tests/extract_spellout_values.py
+++ b/quantulum3/_lang/en_US/tests/extract_spellout_values.py
@@ -23,7 +23,7 @@ TEST_CASES = [
     ("twenty thirty fifty hundred", ["20.0", "30.0", "5000.0"]),
     ("one, two, three", ["1.0", "2.0", "3.0"]),
     ("twenty five thirty six one hundred", ["25.0", "36.0", "100.0"]),
-    ("hundred and five hundred and six", ["105.0", "106.0"]), # this is ambiguous..
+    ("hundred and five hundred and six", ["105.0", "106.0"]),  # this is ambiguous..
     ("hundred and five twenty two", ["105.0", "22.0"]),
     ("hundred and five twenty two million", ["105.0", "22000000.0"]),
 ]

--- a/quantulum3/_lang/en_US/tests/extract_spellout_values.py
+++ b/quantulum3/_lang/en_US/tests/extract_spellout_values.py
@@ -1,0 +1,49 @@
+import unittest
+from ..parser import extract_spellout_values, split_spellout_sequence
+
+
+SPLIT_TEST_CASES = [
+  ("one two three", ["one", "two", "three"]),
+  ("one, two, three", ["one", "two", "three"]),
+  ("twenty five thirty six one hudred", ["twenty five", "thirty six", "one hundred"]),
+  ("hundred and five hundred and six", ["hundred and five", "hundred and six"]),
+  ("hundred and five twenty two", ["hundred and five", "twenty two"]),
+  ("hundred and five twenty two million", ["hundred and five", "twenty two million"]),
+]
+class SplitSpellout(unittest.TestCase):
+    def test_training(self, lang="en_US"):
+        """Test that classifier training works"""
+        for input, expected in SPLIT_TEST_CASES:
+          print("---------input", input)
+          output = [v[0] for v in split_spellout_sequence(input, (0,0))]
+          self.assertEquals(output, expected)
+
+TEST_CASES = [
+  ("one hundred and five", ["105.0"]),
+  ("a million", ["1000000.0"]),
+  ("a million and one", ["1000001.0"]),
+  ("million", ["1000000.0"]),
+  ("million and one", ["1000001.0"]),
+  ("one hundred million", ["100000000.0"]),
+  ("one hundred and five million", ["105000000.0"]),
+  ("half", ["0.5"]),
+  ("two and a half", ["2.5"]),
+  ("two and a half million", ["2500000.0"]),
+  ("twenty six million and seventy two hundred", ["26007200.0"]),
+  #("a million and a half", ["1500000.0"]), # this is a hard one
+  ("twenty", ["20.0"]),
+  #("twenty thirty fifty hundred", ["20.0", "30.0", "4000.0"]),
+  #("one, two, three", ["1.0", "2.0", "3.0"]),
+]
+class ExtractSpellout(unittest.TestCase):
+    def test_training(self, lang="en_US"):
+        """Test that classifier training works"""
+        for input, expected in TEST_CASES:
+          print("---------input", input)
+          output = [v["new_surface"] for v in extract_spellout_values(input)]
+          self.assertEquals(output, expected)
+
+###############################################################################
+if __name__ == "__main__":  # pragma: no cover
+
+    unittest.main()

--- a/quantulum3/_lang/en_US/tests/extract_spellout_values.py
+++ b/quantulum3/_lang/en_US/tests/extract_spellout_values.py
@@ -31,10 +31,11 @@ TEST_CASES = [
 
 class ExtractSpellout(unittest.TestCase):
     def test_training(self, lang="en_US"):
-        """Test that classifier training works"""
+        """Test extraction and conversion of spellout numbers from text"""
+        self.assertEqual(lang, "en_US")
         for input, expected in TEST_CASES:
             output = [v["new_surface"] for v in extract_spellout_values(input)]
-            self.assertEquals(output, expected)
+            self.assertEqual(output, expected)
 
 
 ###############################################################################

--- a/quantulum3/_lang/en_US/tests/extract_spellout_values.py
+++ b/quantulum3/_lang/en_US/tests/extract_spellout_values.py
@@ -34,12 +34,13 @@ TEST_CASES = [
 
 
 class ExtractSpellout(unittest.TestCase):
-    def test_training(self, lang="en_US"):
+    def test_spellout_values(self, lang="en_US"):
         """Test extraction and conversion of spellout numbers from text"""
         self.assertEqual(lang, "en_US")
         for input, expected in TEST_CASES:
-            output = [v["new_surface"] for v in extract_spellout_values(input)]
-            self.assertEqual(output, expected)
+            with self.subTest(input=input):
+                output = [v["new_surface"] for v in extract_spellout_values(input)]
+                self.assertEqual(output, expected)
 
 
 ###############################################################################

--- a/quantulum3/_lang/en_US/tests/extract_spellout_values.py
+++ b/quantulum3/_lang/en_US/tests/extract_spellout_values.py
@@ -18,7 +18,12 @@ TEST_CASES = [
     ("zero", ["0.0"]),
     ("several hundred years", []),
     ("Zero is a small number.", ["0.0", "1.0"]),
-    # ("a million and a half", ["1500000.0"]), # this is a hard one
+    ("a million and a half", ["1000000.5"]),
+    ("one and a half million", ["1500000.0"]),
+    ("two hundred fifty thousand and twenty two", ["250022.0"]),
+    ("ninety nine", ["99.0"]),
+    ("two thousand six hundred forty five", ["2645.0"]),
+    ("seven million five hundred twenty thousand", ["7520000.0"]),
     ## number splitting
     ("twenty thirty fifty hundred", ["20.0", "30.0", "5000.0"]),
     ("one, two, three", ["1.0", "2.0", "3.0"]),

--- a/quantulum3/_lang/en_US/tests/extract_spellout_values.py
+++ b/quantulum3/_lang/en_US/tests/extract_spellout_values.py
@@ -1,6 +1,6 @@
 import unittest
-from ..parser import extract_spellout_values
 
+from ..parser import extract_spellout_values
 
 TEST_CASES = [
     ("one hundred and five", ["105.0"]),

--- a/quantulum3/_lang/en_US/tests/extract_spellout_values.py
+++ b/quantulum3/_lang/en_US/tests/extract_spellout_values.py
@@ -15,6 +15,8 @@ TEST_CASES = [
     ("two and a half million", ["2500000.0"]),
     ("twenty six million and seventy two hundred", ["26007200.0"]),
     ("twenty", ["20.0"]),
+    ("zero", ["0.0"]),
+    ("several hundred years", []),
     # ("a million and a half", ["1500000.0"]), # this is a hard one
     # ("twenty thirty fifty hundred", ["20.0", "30.0", "5000.0"]),
     # ("one, two, three", ["1.0", "2.0", "3.0"]),
@@ -25,7 +27,6 @@ class ExtractSpellout(unittest.TestCase):
     def test_training(self, lang="en_US"):
         """Test that classifier training works"""
         for input, expected in TEST_CASES:
-            print("---------input", input)
             output = [v["new_surface"] for v in extract_spellout_values(input)]
             self.assertEquals(output, expected)
 

--- a/quantulum3/_lang/en_US/tests/extract_spellout_values.py
+++ b/quantulum3/_lang/en_US/tests/extract_spellout_values.py
@@ -3,29 +3,32 @@ from ..parser import extract_spellout_values
 
 
 TEST_CASES = [
-  ("one hundred and five", ["105.0"]),
-  ("a million", ["1000000.0"]),
-  ("a million and one", ["1000001.0"]),
-  ("million", ["1000000.0"]),
-  ("million and one", ["1000001.0"]),
-  ("one hundred million", ["100000000.0"]),
-  ("one hundred and five million", ["105000000.0"]),
-  ("half", ["0.5"]),
-  ("two and a half", ["2.5"]),
-  ("two and a half million", ["2500000.0"]),
-  ("twenty six million and seventy two hundred", ["26007200.0"]),
-  ("twenty", ["20.0"]),
-  #("a million and a half", ["1500000.0"]), # this is a hard one
-  #("twenty thirty fifty hundred", ["20.0", "30.0", "5000.0"]),
-  #("one, two, three", ["1.0", "2.0", "3.0"]),
+    ("one hundred and five", ["105.0"]),
+    ("a million", ["1000000.0"]),
+    ("a million and one", ["1000001.0"]),
+    ("million", ["1000000.0"]),
+    ("million and one", ["1000001.0"]),
+    ("one hundred million", ["100000000.0"]),
+    ("one hundred and five million", ["105000000.0"]),
+    ("half", ["0.5"]),
+    ("two and a half", ["2.5"]),
+    ("two and a half million", ["2500000.0"]),
+    ("twenty six million and seventy two hundred", ["26007200.0"]),
+    ("twenty", ["20.0"]),
+    # ("a million and a half", ["1500000.0"]), # this is a hard one
+    # ("twenty thirty fifty hundred", ["20.0", "30.0", "5000.0"]),
+    # ("one, two, three", ["1.0", "2.0", "3.0"]),
 ]
+
+
 class ExtractSpellout(unittest.TestCase):
     def test_training(self, lang="en_US"):
         """Test that classifier training works"""
         for input, expected in TEST_CASES:
-          print("---------input", input)
-          output = [v["new_surface"] for v in extract_spellout_values(input)]
-          self.assertEquals(output, expected)
+            print("---------input", input)
+            output = [v["new_surface"] for v in extract_spellout_values(input)]
+            self.assertEquals(output, expected)
+
 
 ###############################################################################
 if __name__ == "__main__":  # pragma: no cover

--- a/quantulum3/_lang/en_US/tests/extract_spellout_values.py
+++ b/quantulum3/_lang/en_US/tests/extract_spellout_values.py
@@ -17,9 +17,15 @@ TEST_CASES = [
     ("twenty", ["20.0"]),
     ("zero", ["0.0"]),
     ("several hundred years", []),
+    ("Zero is a small number.", ["0.0", "1.0"]),
     # ("a million and a half", ["1500000.0"]), # this is a hard one
-    # ("twenty thirty fifty hundred", ["20.0", "30.0", "5000.0"]),
-    # ("one, two, three", ["1.0", "2.0", "3.0"]),
+    ## number splitting
+    ("twenty thirty fifty hundred", ["20.0", "30.0", "5000.0"]),
+    ("one, two, three", ["1.0", "2.0", "3.0"]),
+    ("twenty five thirty six one hundred", ["25.0", "36.0", "100.0"]),
+    ("hundred and five hundred and six", ["105.0", "106.0"]), # this is ambiguous..
+    ("hundred and five twenty two", ["105.0", "22.0"]),
+    ("hundred and five twenty two million", ["105.0", "22000000.0"]),
 ]
 
 


### PR DESCRIPTION
This fixes various errors in converting spelled out numbers to numbers: `million`, `million and one`, `one hundred and five million`