### PR TITLE
Enhance parsing of ranges to better handle negative values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ script:
   - coverage run -a --source=quantulum3 setup.py test -s quantulum3.tests.test_hypothesis
   # Test whether quantulum works without classifier
   - coverage run -a --source=quantulum3 setup.py test -s quantulum3.tests.test_no_classifier
+  # Test whether quantulum parses ranges correctly
+  - coverage run -a --source=quantulum3 setup.py test -s quantulum3.tests.test_parse_ranges
   # Test language specific non-classifier tasks
   - coverage run -a --source=quantulum3 setup.py test -s quantulum3._lang.en_US.tests.extract_spellout_values
   # Test requirements.txt for classifier requirements

--- a/quantulum3/_lang/en_US/tests/quantities.json
+++ b/quantulum3/_lang/en_US/tests/quantities.json
@@ -1554,5 +1554,17 @@
           "surface": "3 hrs"
         }
     ]
-  }
+  },
+  {
+  "req": "-78-0 degrees Celsius, DMF, ammonia",
+  "res": [
+      {
+        "value": -39,
+        "unit": "degree Celsius",
+        "surface": "-78-0 degrees Celsius",
+        "entity": "temperature",
+        "uncertainty": 39
+      }
+  ]
+}
 ]

--- a/quantulum3/parser.py
+++ b/quantulum3/parser.py
@@ -72,6 +72,26 @@ def is_ranged(quantity1, quantity2, context, lang="en_US"):
 
 
 ###############################################################################
+def split_range(value: str, range_seperator: str) -> list[str]:
+    values = value.split(range_seperator)
+    values = [v.strip() for v in values]
+
+    if range_seperator in ["-", "–", "—"]:
+        # if we have an empty string, this indicates we have a range which is using the
+        # same symbol to seperate the range and the negative sign
+        # add the negative sign to the front of the next value
+        # remove the empty string
+        for ii in range(len(values)):
+            if values[ii] == "":
+                values[ii + 1] = range_seperator + values[ii + 1]
+                values[ii] = None
+
+    values = [v for v in values if v is not None]
+
+    return values
+
+
+###############################################################################
 def get_values(item, lang="en_US"):
     """
     Extract value from regex hit. context is the enclosing text on which the regex hit.
@@ -110,7 +130,7 @@ def get_values(item, lang="en_US"):
     uncertainty = None
     if range_separator:
         # A range just describes an uncertain quantity
-        values = value.split(range_separator[0])
+        values = split_range(value, range_separator[0])
         values = [
             float(re.sub(r"-$", "", v)) * factors[i] for i, v in enumerate(values)
         ]

--- a/quantulum3/parser.py
+++ b/quantulum3/parser.py
@@ -72,7 +72,7 @@ def is_ranged(quantity1, quantity2, context, lang="en_US"):
 
 
 ###############################################################################
-def split_range(value: str, range_seperator: str) -> list[str]:
+def split_range(value, range_seperator):
     values = value.split(range_seperator)
     values = [v.strip() for v in values]
 

--- a/quantulum3/tests/test_parse_ranges.py
+++ b/quantulum3/tests/test_parse_ranges.py
@@ -9,7 +9,7 @@ import unittest
 from quantulum3 import parser as p
 
 
-class ParserTest(unittest.TestCase):
+class RangeParse(unittest.TestCase):
     """Test suite for the functions in the parser module."""
 
     def test_split_range(self):

--- a/quantulum3/tests/test_parser.py
+++ b/quantulum3/tests/test_parser.py
@@ -5,6 +5,7 @@
 """
 
 import unittest
+
 from quantulum3 import parser as p
 
 
@@ -12,48 +13,17 @@ class ParserTest(unittest.TestCase):
     """Test suite for the functions in the parser module."""
 
     def test_split_range(self):
-
         test_data = {
-            "1-2": {
-                "separator": "-",
-                "expected": ["1", "2"]
-            },
-            "1 - 2": {
-                "separator": "-",
-                "expected": ["1", "2"]
-            },
-            "-1 - 2": {
-                "separator": "-",
-                "expected": ["-1", "2"]
-            },
-            "1 - -2": {
-                "separator": "-",
-                "expected": ["1", "-2"]
-            },
-            "-1--2": {
-                "separator": "-",
-                "expected": ["-1", "-2"]
-            },
-            "1-2-3": {
-                "separator": "-",
-                "expected": ["1", "2", "3"]
-            },
-            "-1--2--3": {
-                "separator": "-",
-                "expected": ["-1", "-2", "-3"]
-            },
-            "1—2": { 
-                "separator": "—",
-                "expected": ["1", "2"]
-            },
-            "-1—2": {
-                "separator": "—",
-                "expected": ["-1", "2"]
-            },
-            "1—-2": {
-                "separator": "—",
-                "expected": ["1", "-2"]
-            },
+            "1-2": {"separator": "-", "expected": ["1", "2"]},
+            "1 - 2": {"separator": "-", "expected": ["1", "2"]},
+            "-1 - 2": {"separator": "-", "expected": ["-1", "2"]},
+            "1 - -2": {"separator": "-", "expected": ["1", "-2"]},
+            "-1--2": {"separator": "-", "expected": ["-1", "-2"]},
+            "1-2-3": {"separator": "-", "expected": ["1", "2", "3"]},
+            "-1--2--3": {"separator": "-", "expected": ["-1", "-2", "-3"]},
+            "1—2": {"separator": "—", "expected": ["1", "2"]},
+            "-1—2": {"separator": "—", "expected": ["-1", "2"]},
+            "1—-2": {"separator": "—", "expected": ["1", "-2"]},
         }
 
         for test, values in test_data.items():

--- a/quantulum3/tests/test_parser.py
+++ b/quantulum3/tests/test_parser.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+:mod:`Quantulum` tests.
+"""
+
+import unittest
+from quantulum3 import parser as p
+
+
+class ParserTest(unittest.TestCase):
+    """Test suite for the functions in the parser module."""
+
+    def test_split_range(self):
+
+        test_data = {
+            "1-2": {
+                "separator": "-",
+                "expected": ["1", "2"]
+            },
+            "1 - 2": {
+                "separator": "-",
+                "expected": ["1", "2"]
+            },
+            "-1 - 2": {
+                "separator": "-",
+                "expected": ["-1", "2"]
+            },
+            "1 - -2": {
+                "separator": "-",
+                "expected": ["1", "-2"]
+            },
+            "-1--2": {
+                "separator": "-",
+                "expected": ["-1", "-2"]
+            },
+            "1-2-3": {
+                "separator": "-",
+                "expected": ["1", "2", "3"]
+            },
+            "-1--2--3": {
+                "separator": "-",
+                "expected": ["-1", "-2", "-3"]
+            },
+            "1—2": { 
+                "separator": "—",
+                "expected": ["1", "2"]
+            },
+            "-1—2": {
+                "separator": "—",
+                "expected": ["-1", "2"]
+            },
+            "1—-2": {
+                "separator": "—",
+                "expected": ["1", "-2"]
+            },
+        }
+
+        for test, values in test_data.items():
+            separator = values["separator"]
+            expected = values["expected"]
+            values = p.split_range(test, separator)
+            self.assertEqual(values, expected)


### PR DESCRIPTION
quantulum was failing to parse some temperature ranges in my dataset that had negative numbers , eg. -78 - 0 degrees Celsius.

quantulum was correctly identifying the range separator but the split function was over eager when trying to split the values, removing the negative sign, and creating a list like: ["", "78", "0"] as the range separator was the same as the negative sign. When trying to cast "" to a float, an exception is thrown and the quantity is lost.

I have enhanced the range splitting to try and identify and correctly handle these cases. It works on my dataset and handles the test cases I have curated, but don't know the code base well enough to foresee if this will work well in the general case.