### PR TITLE
replace "log" with "log_loss" in sklearn SGD parameters

### DIFF
--- a/quantulum3/classifier.py
+++ b/quantulum3/classifier.py
@@ -171,7 +171,7 @@ def train_classifier(
 
     if parameters is None:
         parameters = {
-            "loss": "log",
+            "loss": "log_loss",
             "penalty": "l2",
             "tol": 1e-3,
             "n_jobs": n_jobs,


### PR DESCRIPTION
"log" will be deprecated in 1.3, replace with functionally equivalent "log_loss"