### PR TITLE
custom units and entities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
   - coverage run -a --source=quantulum3 setup.py test -s quantulum3.tests.test_classifier.ClassifierTest
   - coverage run -a --source=quantulum3 setup.py test -s quantulum3.tests.test_scripts.TrainScriptTest
   - coverage run -a --source=quantulum3 setup.py test -s quantulum3.tests.test_load.TestCached
-
+  - coverage run -a --source=quantulum3 setup.py test -s quantulum3.tests.test_load.TestLoaders
 after_success:
   - coverage report
   - coveralls

--- a/README.md
+++ b/README.md
@@ -174,10 +174,10 @@ If you want to train the classifier yourself, you will need the dependencies for
 Use `quantulum3-training` on the command line, the script `quantulum3/scripts/train.py` or the method `train_classifier` in `quantulum3.classifier` to train the classifier.
 
 ``` bash
-quantulum3-training --lang <language> --data <path/to/training/data/directory> --output <path/to/output/file.joblib>
+quantulum3-training --lang <language> --data <path/to/training/file.json> --output <path/to/output/file.joblib>
 ```
 
-All .json files in the training data directory will be used for training, and the output is in joblib format.
+You can pass multiple training files in to the training command. The output is in joblib format.
 
 To use your custom model, pass the path to the trained model file to the
 parser:

--- a/README.md
+++ b/README.md
@@ -219,16 +219,31 @@ to the properties of the unit to be created.
 
 It is possible to load a completely custom set of units and entities. This can be done by passing a list of file paths to the load_custom_units and load_custom_entities functions. Loading custom untis and entities will replace the default units and entities that are normally loaded.
 
+The recomended way to load quantities is via a context manager:
+
+```pycon
+>>> from quantulum3 import load, parser
+>>> with load.CustomQuantities(["path/to/units.json"], ["path/to/entities.json"]):
+>>>     parser.parse("This extremely sharp tool is precise up to 0.5 slp")
+
+[Quantity(0.5, "Unit(name="schlurp", entity=Entity("dimensionless"), uri=None)")]
+
+>>> # default units and entities are loaded again
+```
+
+But it is also possible to load custom units and entities manually:
+
 ```pycon
 >>> from quantulum3 import load, parser
 
 >>> load.load_custom_units(["path/to/units.json"])
 >>> load.load_custom_entities(["path/to/entities.json"])
-
->>> # parse text as normal
 >>> parser.parse("This extremely sharp tool is precise up to 0.5 slp")
 
 [Quantity(0.5, "Unit(name="schlurp", entity=Entity("dimensionless"), uri=None)")]
+
+>>> # remove custom units and entities and load default units and entities
+>>> load.reset_quantities()
 ```
 
 See the Developer Guide below for more information about the format of units and entities files.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-quantulum3
-==========
+# quantulum3
+
  [![Travis master build state](https://app.travis-ci.com/nielstron/quantulum3.svg?branch=master "Travis master build state")](https://app.travis-ci.com/nielstron/quantulum3)
  [![Coverage Status](https://coveralls.io/repos/github/nielstron/quantulum3/badge.svg?branch=master)](https://coveralls.io/github/nielstron/quantulum3?branch=master)
  [![PyPI version](https://badge.fury.io/py/quantulum3.svg)](https://pypi.org/project/quantulum3/)
  ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/quantulum3.svg)
  [![PyPI - Status](https://img.shields.io/pypi/status/quantulum3.svg)](https://pypi.org/project/quantulum3/)
- 
+
 Python library for information extraction of quantities, measurements
 and their units from unstructured text. It is able to disambiguate between similar
 looking units based on their *k-nearest neighbours* in their [GloVe](https://nlp.stanford.edu/projects/glove/) vector representation
@@ -18,23 +18,23 @@ Lagi](https://github.com/marcolagi/quantulum).
 The compatibility with the newest version of sklearn is based on
 the fork of [sohrabtowfighi](https://github.com/sohrabtowfighi/quantulum).
 
-Installation
-------------
+## User Guide
+
+### Installation
 
 ```bash
-$ pip install quantulum3
+pip install quantulum3
 ```
 
 To install dependencies for using or training the disambiguation classifier, use
 
 ```bash
-$ pip install quantulum3[classifier]
+pip install quantulum3[classifier]
 ```
 
 The disambiguation classifier is used when the parser find two or more units that are a match for the text.
 
-Usage
------
+### Usage
 
 ```pycon
 >>> from quantulum3 import parser
@@ -79,8 +79,7 @@ this library can also be used for simple number extraction.
 [Quantity(2, 'dimensionless')]
 ```
 
-Units and entities
-------------------
+### Units and entities
 
 All units (e.g. *litre*) and the entities they are associated to (e.g.
 *volume*) are reconciled against WikiPedia:
@@ -117,8 +116,7 @@ dimensionality:
 Unit(name="kilometre per second", entity=Entity("speed"), uri=None)
 ```
 
-Disambiguation
---------------
+### Disambiguation
 
 If the parser detects an ambiguity, a classifier based on the WikiPedia
 pages of the ambiguous units or entities tries to guess the right one:
@@ -147,26 +145,46 @@ In addition to that, the classifier is trained on the most similar words to
 all of the units surfaces, according to their distance in [GloVe](https://nlp.stanford.edu/projects/glove/)
 vector representation.
 
-Training the classifier
------------------------
+## Spoken version
 
-If you want to train the classifier yourself, in addition to the packages above, you'll also need
-the packages `stemming` and `wikipedia`.
+Quantulum classes include methods to convert them to a speakable unit.
 
-You can get the classifier dependencies by running
-
-```bash
-$ pip install quantulum3[classifier]
+```pycon
+>>> parser.parse("Gimme 10e9 GW now!")[0].to_spoken()
+ten billion gigawatts
+>>> parser.inline_parse_and_expand("Gimme $1e10 now and also 1 TW and 0.5 J!")
+Gimme ten billion dollars now and also one terawatt and zero point five joules!
 ```
 
-You could also [download requirements_classifier.txt](https://raw.githubusercontent.com/nielstron/quantulum3/dev/requirements_classifier.txt)
-and run
+### Manipulation
 
-```bash
-$ pip install -r requirements_classifier.txt
-```
+While quantities cannot be manipulated within this library, there are
+many great options out there:
+
+- [pint](https://pint.readthedocs.org/en/latest/)
+- [natu](http://kdavies4.github.io/natu/)
+- [quantities](http://python-quantities.readthedocs.org/en/latest/)
+
+## Extension
+
+### Training the classifier
+
+If you want to train the classifier yourself, you will need the dependencies for the classifier (see installation).
 
 Use `quantulum3-training` on the command line, the script `quantulum3/scripts/train.py` or the method `train_classifier` in `quantulum3.classifier` to train the classifier.
+
+``` bash
+quantulum3-training --lang <language> --data <path/to/training/data/directory> --output <path/to/output/file.joblib>
+```
+
+All .json files in the training data directory will be used for training, and the output is in joblib format.
+
+To use your custom model, pass the path to the trained model file to the
+parser:
+
+```pyton
+parser = Parser.parse(<text>, classifier_path="path/to/model.joblib")
+```
 
 Example training files can be found in `quantulum3/_lang/<language>/train`.
 
@@ -183,44 +201,9 @@ converted to a `.magnitude` file on-the-run. Check out
 [pre-formatted Magnitude formatted word-embeddings](https://github.com/plasticityai/magnitude#pre-converted-magnitude-formats-of-popular-embeddings-models)
 and [Magnitude](https://github.com/plasticityai/magnitude) for more information.
 
+### Additional units
 
-To use your custom model, pass the path to the trained model file to the
-parser:
-
-```pyton
-parser = Parser.parse(classifier_path="path/to/model")
-```
-
-
-Manipulation
-------------
-
-While quantities cannot be manipulated within this library, there are
-many great options out there:
-
--   [pint](https://pint.readthedocs.org/en/latest/)
--   [natu](http://kdavies4.github.io/natu/)
--   [quantities](http://python-quantities.readthedocs.org/en/latest/)
-
-Spoken version
---------------
-
-Quantulum classes include methods to convert them to a speakable unit.
-
-```pycon
->>> parser.parse("Gimme 10e9 GW now!")[0].to_spoken()
-ten billion gigawatts
->>> parser.inline_parse_and_expand("Gimme $1e10 now and also 1 TW and 0.5 J!")
-Gimme ten billion dollars now and also one terawatt and zero point five joules!
-```
-
-Extension
----------
-
-#### Custom units
-
-It is possible to add custom entities to be parsed by quantulum.
-See below code for an example invocation.
+It is possible to add additional entities and units to be parsed by quantulum. These will be added to the default units and entities. See below code for an example invocation:
 
 ```pycon
 >>> from quantulum3.load import add_custom_unit, remove_custom_unit
@@ -232,13 +215,33 @@ See below code for an example invocation.
 The keyword arguments to the function `add_custom_unit` are directly translated
 to the properties of the unit to be created.
 
-#### Extending the set of default units
+### Custom Units and Entities
+
+It is possible to load a completely custom set of units and entities. This can be done by passing a list of file paths to the load_custom_units and load_custom_entities functions. Loading custom untis and entities will replace the default units and entities that are normally loaded.
+
+```pycon
+>>> from quantulum3 import load, parser
+
+>>> load.load_custom_units(["path/to/units.json"])
+>>> load.load_custom_entities(["path/to/entities.json"])
+
+>>> # parse text as normal
+>>> parser.parse("This extremely sharp tool is precise up to 0.5 slp")
+
+[Quantity(0.5, "Unit(name="schlurp", entity=Entity("dimensionless"), uri=None)")]
+```
+
+See the Developer Guide below for more information about the format of units and entities files.
+
+## Developer Guide
+
+### Adding Units and Entities
 
 See *units.json* for the complete list of units and *entities.json* for
 the complete list of entities. The criteria for adding units have been:
 
--   the unit has (or is redirected to) a WikiPedia page
--   the unit is in common use (e.g. not the [premetric Swedish units of
+- the unit has (or is redirected to) a WikiPedia page
+- the unit is in common use (e.g. not the [premetric Swedish units of
     measurement](https://en.wikipedia.org/wiki/Swedish_units_of_measurement#Length)).
 
 It\'s easy to extend these two files to the units/entities of interest.
@@ -251,9 +254,9 @@ Here is an example of an entry in *entities.json*:
 }
 ```
 
--   The *name* of an entity is its key. Names are required to be unique.
--   *URI* is the name of the wikipedia page of the entity. (i.e. `https://en.wikipedia.org/wiki/Speed` => `Speed`)
--   *dimensions* is the dimensionality, a list of dictionaries each
+- The *name* of an entity is its key. Names are required to be unique.
+- *URI* is the name of the wikipedia page of the entity. (i.e. `https://en.wikipedia.org/wiki/Speed` => `Speed`)
+- *dimensions* is the dimensionality, a list of dictionaries each
     having a *base* (the name of another entity) and a *power* (an
     integer, can be negative).
 
@@ -277,24 +280,24 @@ Here is an example of an entry in *units.json*:
 }
 ```
 
--   The *name* of a unit is its key. Names are required to be unique.
--   *URI* follows the same scheme as in the *entities.json*
--   *surfaces* is a list of strings that refer to that unit. The library
+- The *name* of a unit is its key. Names are required to be unique.
+- *URI* follows the same scheme as in the *entities.json*
+- *surfaces* is a list of strings that refer to that unit. The library
     takes care of plurals, no need to specify them.
--   *entity* is the name of an entity in *entities.json*
--   *dimensions* follows the same schema as in *entities.json*, but the
+- *entity* is the name of an entity in *entities.json*
+- *dimensions* follows the same schema as in *entities.json*, but the
     *base* is the name of another unit, not of another entity.
--   *symbols* is a list of possible symbols and abbreviations for that
+- *symbols* is a list of possible symbols and abbreviations for that
     unit.
--   *prefixes* is an optional list. It can contain [Metric](https://en.wikipedia.org/wiki/Metric_prefix) and [Binary prefixes](https://en.wikipedia.org/wiki/Binary_prefix) and
+- *prefixes* is an optional list. It can contain [Metric](https://en.wikipedia.org/wiki/Metric_prefix) and [Binary prefixes](https://en.wikipedia.org/wiki/Binary_prefix) and
     automatically generates according units. If you want to
     add specifics (like different surfaces) you need to create an entry for that
     prefixes version on its own.
 
 All fields are case sensitive.
 
-Contributing
-------------
+### Contributing
+
 `dev` build: 
 
 [![Travis dev build state](https://travis-ci.com/nielstron/quantulum3.svg?branch=dev "Travis dev build state")](https://travis-ci.com/nielstron/quantulum3)
@@ -311,8 +314,8 @@ If you'd like to contribute follow these steps:
 (Optional, will be done automatically after pushing)
 8. Create a Pull Request when having commited and pushed your changes
 
-Language support
-----------------
+### Language support
+
 [![Travis dev build state](https://travis-ci.com/nielstron/quantulum3.svg?branch=language_support "Travis dev build state")](https://travis-ci.com/nielstron/quantulum3)
 [![Coverage Status](https://coveralls.io/repos/github/nielstron/quantulum3/badge.svg?branch=language_support)](https://coveralls.io/github/nielstron/quantulum3?branch=dev)
 
@@ -326,4 +329,3 @@ as in the automatic unittests.
 
 No changes outside the own language submodule folder (i.e. `_lang.de_DE`) should
 be necessary. If there are problems implementing a new language, don't hesitate to open an issue.
-

--- a/quantulum3/_lang/en_US/load.py
+++ b/quantulum3/_lang/en_US/load.py
@@ -31,6 +31,7 @@ def number_to_words(number):
 ###############################################################################
 def build_common_words():
     # Read raw 4 letter file
+    units_ = load.units(lang)
     path = os.path.join(TOPDIR, "common-units.txt")
     with open(path, "r", encoding="utf-8") as file:
         common_units = {line.strip() for line in file if not line.startswith("#")}
@@ -42,15 +43,15 @@ def build_common_words():
                 continue
             line = line.rstrip()
             if (
-                line not in load.units(lang).surfaces_lower
-                and line not in load.units(lang).symbols
+                line not in units_.surfaces_lower
+                and line not in units_.symbols
                 and line not in common_units
             ):
                 words[len(line)].append(line)
             plural = load.pluralize(line)
             if (
-                plural not in load.units(lang).surfaces_all
-                and plural not in load.units(lang).symbols
+                plural not in units_.surfaces_all
+                and plural not in units_.symbols
                 and plural not in common_units
             ):
                 words[len(plural)].append(plural)

--- a/quantulum3/_lang/en_US/parser.py
+++ b/quantulum3/_lang/en_US/parser.py
@@ -242,6 +242,9 @@ def build_quantity(
     """
     # TODO rerun if change occurred
     # Re parse unit if a change occurred
+
+    units_ = load.units(lang)
+
     dimension_change = True
 
     # Extract "absolute " ...
@@ -250,7 +253,7 @@ def build_quantity(
         unit.name == "dimensionless"
         and _absolute == orig_text[span[0] - len(_absolute) : span[0]]
     ):
-        unit = load.units(lang).names["kelvin"]
+        unit = units_.names["kelvin"]
         unit.original_dimensions = unit.dimensions
         surface = _absolute + surface
         span = (span[0] - len(_absolute), span[1])
@@ -278,7 +281,7 @@ def build_quantity(
             # k/M etc is only applied if non-symbolic surfaces of other units
             # (because colloquial) or currency units
             symbolic = all(
-                dim["surface"] in load.units(lang).names[dim["base"]].symbols
+                dim["surface"] in units_.names[dim["base"]].symbols
                 for dim in unit.original_dimensions[1:]
             )
             if not symbolic:
@@ -430,7 +433,7 @@ def build_quantity(
                 unit.original_dimensions, orig_text, lang, classifier_path
             )
         else:
-            unit = load.units(lang).names["dimensionless"]
+            unit = units_.names["dimensionless"]
 
     # Discard irrelevant txt2float extractions, cardinal numbers, codes etc.
     if (

--- a/quantulum3/classifier.py
+++ b/quantulum3/classifier.py
@@ -234,7 +234,7 @@ class Classifier(object):
         if not classifier_object:
             if classifier_path is None:
                 classifier_path = language.topdir(lang).joinpath("clf.joblib")
-            with classifier_path.open("rb") as file:
+            with open(classifier_path, "rb") as file:
                 classifier_object = joblib.load(file)
 
         cur_scipy_version = pkg_resources.get_distribution("scikit-learn").version

--- a/quantulum3/classifier.py
+++ b/quantulum3/classifier.py
@@ -202,7 +202,7 @@ def train_classifier(
             path = language.topdir(lang).joinpath("clf.joblib")
 
         _LOGGER.info("Store classifier at {}".format(path))
-        with path.open("wb") as file:
+        with open(path, "wb") as file:
             joblib.dump(obj, file)
     return obj
 

--- a/quantulum3/disambiguate.py
+++ b/quantulum3/disambiguate.py
@@ -17,11 +17,12 @@ def disambiguate_unit(unit_surface, text, lang="en_US", classifier_path=None):
     if clf.USE_CLF:
         base = clf.disambiguate_unit(unit_surface, text, lang, classifier_path).name
     else:
+        units_ = load.units(lang)
         base = (
-            load.units(lang).symbols[unit_surface]
-            or load.units(lang).surfaces[unit_surface]
-            or load.units(lang).surfaces_lower[unit_surface.lower()]
-            or load.units(lang).symbols_lower[unit_surface.lower()]
+            units_.symbols[unit_surface]
+            or units_.surfaces[unit_surface]
+            or units_.surfaces_lower[unit_surface.lower()]
+            or units_.symbols_lower[unit_surface.lower()]
         )
 
         if len(base) > 1:
@@ -42,14 +43,17 @@ def disambiguate_entity(key, text, lang="en_US", classifier_path=None):
     """
     Resolve ambiguity between entities with same dimensionality.
     """
+
+    entities_ = load.entities(lang)
+
     try:
         if clf.USE_CLF:
             ent = clf.disambiguate_entity(key, text, lang, classifier_path)
         else:
-            derived = load.entities().derived[key]
+            derived = entities_.derived[key]
             if len(derived) > 1:
                 ent = no_clf.disambiguate_no_classifier(derived, text, lang)
-                ent = load.entities().names[ent]
+                ent = entities_.names[ent]
             elif len(derived) == 1:
                 ent = next(iter(derived))
             else:

--- a/quantulum3/load.py
+++ b/quantulum3/load.py
@@ -24,6 +24,19 @@ def clear_caches():
     clear_cache()
 
 
+def reset_units_and_entities_loading():
+    global USE_GENERAL_UNITS, USE_GENERAL_ENTITIES, USE_LANGUAGE_UNITS, USE_LANGUAGE_ENTITIES, USE_CUSTOM_UNITS, USE_CUSTOM_ENTITIES, USE_ADDITIONAL_UNITS, USE_ADDITIONAL_ENTITIES
+
+    USE_GENERAL_UNITS = True
+    USE_GENERAL_ENTITIES = True
+    USE_LANGUAGE_UNITS = True
+    USE_LANGUAGE_ENTITIES = True
+    USE_CUSTOM_UNITS = False
+    USE_CUSTOM_ENTITIES = False
+    USE_ADDITIONAL_UNITS = True
+    USE_ADDITIONAL_ENTITIES = True
+
+
 def clear_cache():
     """
     Useful for testing.

--- a/quantulum3/load.py
+++ b/quantulum3/load.py
@@ -24,7 +24,7 @@ def clear_caches():
     clear_cache()
 
 
-def reset_units_and_entities_loading():
+def reset_quantities():
     global USE_GENERAL_UNITS, USE_GENERAL_ENTITIES, USE_LANGUAGE_UNITS, USE_LANGUAGE_ENTITIES, USE_CUSTOM_UNITS, USE_CUSTOM_ENTITIES, USE_ADDITIONAL_UNITS, USE_ADDITIONAL_ENTITIES
 
     USE_GENERAL_UNITS = True
@@ -42,6 +42,82 @@ def clear_cache():
     Useful for testing.
     """
     _CACHE_DICT.clear()
+
+
+class CustomQuantities:
+    def __init__(
+        self,
+        custom_units: List[Union[str, Path]] = None,
+        custom_entities: List[Union[str, Path]] = None,
+        use_general_units: bool = False,
+        use_language_units: bool = False,
+        use_additional_units: bool = True,
+        use_general_entities: bool = False,
+        use_language_entities: bool = False,
+        use_additional_entities: bool = True,
+    ):
+        """
+        Load custom unites and entities into Quantulum via a context manager.
+
+        :param custom_units: list of paths to custom units
+        :param custom_entities: list of paths to custom entities
+        :param use_general_units: Whether to also load the general units, by default False
+        :param use_language_units: Whether to also load the language specific units, by default False
+        :param use_additional_units: Whether to also load the additional units, by default True
+        """
+        self.custom_units = custom_units
+        self.custom_entities = custom_entities
+        self.use_general_units = use_general_units
+        self.use_language_units = use_language_units
+        self.use_additional_units = use_additional_units
+        self.use_general_entities = use_general_entities
+        self.use_language_entities = use_language_entities
+        self.use_additional_entities = use_additional_entities
+
+    def __enter__(self):
+        self._record_current_state()
+
+        if self.custom_units:
+            load_custom_units(
+                self.custom_units,
+                use_general_units=self.use_general_units,
+                use_language_units=self.use_language_units,
+                use_additional_units=self.use_additional_units,
+            )
+
+        if self.custom_entities:
+            load_custom_entities(
+                self.custom_entities,
+                use_general_entities=self.use_general_entities,
+                use_language_entities=self.use_language_entities,
+                use_additional_entities=self.use_additional_entities,
+            )
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        # reset flags
+        self._reset_state()
+
+    def _record_current_state(self):
+        self.previous_general_units = USE_GENERAL_UNITS
+        self.previous_general_entities = USE_GENERAL_ENTITIES
+        self.previous_language_units = USE_LANGUAGE_UNITS
+        self.previous_language_entities = USE_LANGUAGE_ENTITIES
+        self.previous_custom_units = USE_CUSTOM_UNITS
+        self.previous_custom_entities = USE_CUSTOM_ENTITIES
+        self.previous_additional_units = USE_ADDITIONAL_UNITS
+        self.previous_additional_entities = USE_ADDITIONAL_ENTITIES
+
+    def _reset_state(self):
+        global USE_GENERAL_UNITS, USE_GENERAL_ENTITIES, USE_LANGUAGE_UNITS, USE_LANGUAGE_ENTITIES, USE_CUSTOM_UNITS, USE_CUSTOM_ENTITIES, USE_ADDITIONAL_UNITS, USE_ADDITIONAL_ENTITIES
+
+        USE_GENERAL_UNITS = self.previous_general_units
+        USE_GENERAL_ENTITIES = self.previous_general_entities
+        USE_LANGUAGE_UNITS = self.previous_language_units
+        USE_LANGUAGE_ENTITIES = self.previous_language_entities
+        USE_CUSTOM_UNITS = self.previous_custom_units
+        USE_CUSTOM_ENTITIES = self.previous_custom_entities
+        USE_ADDITIONAL_UNITS = self.previous_additional_units
+        USE_ADDITIONAL_ENTITIES = self.previous_additional_entities
 
 
 def cached(funct):

--- a/quantulum3/load.py
+++ b/quantulum3/load.py
@@ -18,6 +18,12 @@ TOPDIR = Path(__file__).parent or Path(".")
 _CACHE_DICT = defaultdict(dict)
 
 
+def clear_caches():
+    clear_units_cache()
+    clear_entities_cache()
+    clear_cache()
+
+
 def clear_cache():
     """
     Useful for testing.
@@ -37,6 +43,7 @@ def cached(funct):
 
     def cached_function(*args, **kwargs):
         # create a hash of args and kwargs
+
         args_hash = hash((args, frozenset(kwargs.items())))
 
         try:
@@ -69,7 +76,9 @@ def _get_load(lang="en_US"):
 
 
 GENERAL_UNITS_PATH = TOPDIR.joinpath("units.json")
+USE_GENERAL_UNITS = True
 GENERAL_ENTITIES_PATH = TOPDIR.joinpath("entities.json")
+USE_GENERAL_ENTITIES = True
 
 
 def LANGUAGE_ENTITIES_PATH(lang="en_US"):
@@ -78,6 +87,10 @@ def LANGUAGE_ENTITIES_PATH(lang="en_US"):
 
 def LANGUAGE_UNITS_PATH(lang="en_US"):
     return TOPDIR.joinpath(language.topdir(lang), "units.json")
+
+
+USE_LANGUAGE_UNITS = True
+USE_LANGUAGE_ENTITIES = True
 
 
 def _load_json(path_or_string: Union[Path, str]):
@@ -100,7 +113,16 @@ def _load_json_dict(path_or_string: Union[Path, str, dict]):
 
 
 CUSTOM_ENTITIES = defaultdict(dict)
+USE_CUSTOM_ENTITIES = True
+
+ADDITIONAL_ENTITIES = defaultdict(dict)
+USE_ADDITIONAL_ENTITIES = True
+
 CUSTOM_UNITS = defaultdict(dict)
+USE_CUSTOM_UNITS = True
+
+ADDITIONAL_UNITS = defaultdict(dict)
+USE_ADDITIONAL_UNITS = True
 
 
 ###############################################################################
@@ -209,6 +231,9 @@ class Entities(object):
 
         self.derived = derived_ent
 
+    def __getitem__(self, item):
+        return self.names[item]
+
     def get_dimension_permutations(self, derived):
         """
         Get all possible dimensional definitions for an entity.
@@ -237,14 +262,53 @@ class Entities(object):
         return candidates
 
 
-@cached
-def entities(lang="en_US"):
+_CACHED_ENTITIES = {}
+
+
+def clear_entities_cache():
+    _CACHED_ENTITIES.clear()
+
+
+def entities(
+    lang: str = "en_US",
+) -> Entities:
     """
     Cached entity object
+
+    Parameters
+    ----------
+    lang : str
+        Language code, loads the default and language specific entities.
+
+    Returns
+    -------
+    Entities
+        Entities object
     """
-    return Entities(
-        [GENERAL_ENTITIES_PATH, LANGUAGE_ENTITIES_PATH(lang), CUSTOM_ENTITIES]
+
+    args_hash = hash(
+        (
+            lang,
+            USE_GENERAL_ENTITIES,
+            USE_LANGUAGE_ENTITIES,
+            USE_ADDITIONAL_ENTITIES,
+            USE_CUSTOM_ENTITIES,
+        )
     )
+    if args_hash not in _CACHED_ENTITIES:
+        entities_list = []
+        if USE_GENERAL_ENTITIES:
+            entities_list.append(GENERAL_ENTITIES_PATH)
+        if USE_LANGUAGE_ENTITIES:
+            entities_list.append(LANGUAGE_ENTITIES_PATH(lang))
+        if USE_ADDITIONAL_ENTITIES:
+            entities_list.append(ADDITIONAL_ENTITIES)
+        if USE_CUSTOM_ENTITIES:
+            entities_list.extend(CUSTOM_ENTITIES)
+
+        _CACHED_ENTITIES[args_hash] = Entities(entities_list)
+
+    return _CACHED_ENTITIES[args_hash]
 
 
 ###############################################################################
@@ -276,6 +340,16 @@ class Units(object):
     def __init__(self, unit_dict_json: List[Union[str, Path, dict]], lang="en_US"):
         """
         Load units from JSON file.
+
+        Parameters
+        ----------
+        unit_paths : List[Union[str, Path, dict]]
+            Paths to unit JSON files.
+        lang : str
+            Language code, loads the default and language specific units.
+        custom_entities : List[Union[Path, str, dict]]
+            Paths to custom entity JSON files. If a list is provided, no default language
+            or general entities will be loaded.
         """
 
         # names of all units
@@ -304,6 +378,9 @@ class Units(object):
         self.surfaces_all = self.surfaces.copy()
         self.surfaces_all.update(self.surfaces_lower)
 
+    def __getitem__(self, name):
+        return self.names[name]
+
     def load_unit(self, name, unit):
         try:
             assert name not in self.names
@@ -314,7 +391,7 @@ class Units(object):
         obj = c.Unit(
             name=name,
             surfaces=unit.get("surfaces", []),
-            entity=entities().names[unit["entity"]],
+            entity=entities(self.lang).names[unit["entity"]],
             uri=unit.get("URI"),
             symbols=unit.get("symbols", []),
             dimensions=unit.get("dimensions", []),
@@ -362,12 +439,54 @@ class Units(object):
             }
 
 
-@cached
-def units(lang="en_US"):
+_CACHED_UNITS = {}
+
+
+def clear_units_cache():
+    _CACHED_UNITS.clear()
+
+
+def units(
+    lang: str = "en_US",
+) -> Units:
     """
     Cached unit object
+
+    Parameters
+    ----------
+    lang : str
+        Language code, loads the default and language specific units.
+
+    Returns
+    -------
+    Units
+        Units object
     """
-    return Units([GENERAL_UNITS_PATH, LANGUAGE_UNITS_PATH(lang), CUSTOM_UNITS], lang)
+
+    args_hash = hash(
+        (
+            lang,
+            USE_GENERAL_UNITS,
+            USE_LANGUAGE_UNITS,
+            USE_ADDITIONAL_UNITS,
+            USE_CUSTOM_UNITS,
+        )
+    )
+
+    if args_hash not in _CACHED_UNITS:
+        units_list = []
+        if USE_GENERAL_UNITS:
+            units_list.append(GENERAL_UNITS_PATH)
+        if USE_LANGUAGE_UNITS:
+            units_list.append(LANGUAGE_UNITS_PATH(lang))
+        if USE_ADDITIONAL_UNITS:
+            units_list.append(ADDITIONAL_UNITS)
+        if USE_CUSTOM_UNITS:
+            units_list.extend(CUSTOM_UNITS)
+
+        _CACHED_UNITS[args_hash] = Units(units_list, lang)
+
+    return _CACHED_UNITS[args_hash]
 
 
 ###############################################################################
@@ -393,8 +512,8 @@ def add_custom_unit(name: str, **kwargs):
     otherwise will overwrite attributes in existing units
     :param kwargs: properties of the unit as found in units.json, i.e. surfaces=["centimetre"]
     """
-    CUSTOM_UNITS[name].update(kwargs)
-    _CACHE_DICT.clear()
+    ADDITIONAL_UNITS[name].update(kwargs)
+    clear_caches()
 
 
 def remove_custom_unit(name: str):
@@ -403,8 +522,8 @@ def remove_custom_unit(name: str):
     Note: causes a reload of all units
     :param name: Name of the unit to remove. This will not affect units that are loaded per default.
     """
-    CUSTOM_UNITS.pop(name)
-    _CACHE_DICT.clear()
+    ADDITIONAL_UNITS.pop(name)
+    clear_caches()
 
 
 def add_custom_entity(name: str, **kwargs):
@@ -415,8 +534,8 @@ def add_custom_entity(name: str, **kwargs):
     otherwise will overwrite attributes in existing entities
     :param kwargs: properties of the entity as found in entities.json, i.e. surfaces=["centimetre"]
     """
-    CUSTOM_ENTITIES[name].update(kwargs)
-    _CACHE_DICT.clear()
+    ADDITIONAL_ENTITIES[name].update(kwargs)
+    clear_caches()
 
 
 def remove_custom_entity(name: str):
@@ -425,5 +544,77 @@ def remove_custom_entity(name: str):
     Note: causes a reload of all entities
     :param name: Name of the entity to remove. This will not affect entities that are loaded per default.
     """
-    CUSTOM_ENTITIES.pop(name)
-    _CACHE_DICT.clear()
+    ADDITIONAL_ENTITIES.pop(name)
+    clear_caches()
+
+
+def load_custom_units(
+    unit_dict_json: List[Union[str, Path]],
+    use_general_units: bool = False,
+    use_language_units: bool = False,
+    use_additional_units: bool = True,
+):
+    """
+    Load custom units from a dictionary or json file.
+
+    Parameters
+    ----------
+    unit_dict_json : List[Dict]
+        A list of dictionaries or paths to json files containing the units to load.
+    use_general_units : bool, optional
+        Whether to also load the general units, by default False
+    use_language_units : bool, optional
+        Whether to also load the language specific units, by default False
+    use_additional_units : bool, optional
+        Whether to also load the additional units (from the add_custom_unit functions), by default True
+    """
+
+    if not isinstance(unit_dict_json, list):
+        unit_dict_json = [unit_dict_json]
+
+    global USE_GENERAL_UNITS, USE_LANGUAGE_UNITS, USE_ADDITIONAL_UNITS, USE_CUSTOM_UNITS, CUSTOM_UNITS
+
+    USE_GENERAL_UNITS = use_general_units
+    USE_LANGUAGE_UNITS = use_language_units
+    USE_ADDITIONAL_UNITS = use_additional_units
+    USE_CUSTOM_UNITS = True
+
+    CUSTOM_UNITS = unit_dict_json
+
+    clear_units_cache()
+
+
+def load_custom_entities(
+    entity_dict_json: List[Union[str, Path]],
+    use_general_entities: bool = False,
+    use_language_entities: bool = False,
+    use_additional_entities: bool = True,
+):
+    """
+    Load custom entities from a dictionary or json file.
+
+    Parameters
+    ----------
+    entity_dict_json : List[Dict]
+        A list of dictionaries or paths to json files containing the entities to load.
+    use_general_entities : bool, optional
+        Whether to also load the general entities, by default False
+    use_language_entities : bool, optional
+        Whether to also load the language specific entities, by default False
+    use_additional_entities : bool, optional
+        Whether to also load the additional entities (from the add_custom_entity functions), by default True
+    """
+
+    if not isinstance(entity_dict_json, list):
+        entity_dict_json = [entity_dict_json]
+
+    global USE_GENERAL_ENTITIES, USE_LANGUAGE_ENTITIES, USE_ADDITIONAL_ENTITIES, USE_CUSTOM_ENTITIES, CUSTOM_ENTITIES
+
+    USE_GENERAL_ENTITIES = use_general_entities
+    USE_LANGUAGE_ENTITIES = use_language_entities
+    USE_ADDITIONAL_ENTITIES = use_additional_entities
+    USE_CUSTOM_ENTITIES = True
+
+    CUSTOM_ENTITIES = entity_dict_json
+
+    clear_entities_cache()

--- a/quantulum3/parser.py
+++ b/quantulum3/parser.py
@@ -282,7 +282,7 @@ def get_entity_from_dimensions(dimensions, text, lang="en_US", classifier_path=N
     final_derived = sorted(new_derived, key=lambda x: x["base"])
     key = load.get_key_from_dimensions(final_derived)
 
-    ent = dis.disambiguate_entity(key, text, lang, classifier_path=classifier_path)
+    ent = dis.disambiguate_entity(key, text, lang, classifier_path)
     if ent is None:
         _LOGGER.debug("\tCould not find entity for: %s", key)
         ent = cls.Entity(name="unknown", dimensions=new_derived)

--- a/quantulum3/regex.py
+++ b/quantulum3/regex.py
@@ -329,15 +329,14 @@ def units_regex(lang="en_US"):
 
     """
 
+    units_ = load.units(lang)
     op_keys = sorted(list(operators(lang)), key=len, reverse=True)
     unit_keys = sorted(
-        list(load.units(lang).surfaces.keys()) + list(load.units(lang).symbols.keys()),
+        list(units_.surfaces.keys()) + list(units_.symbols.keys()),
         key=len,
         reverse=True,
     )
-    symbol_keys = sorted(
-        list(load.units(lang).prefix_symbols.keys()), key=len, reverse=True
-    )
+    symbol_keys = sorted(list(units_.prefix_symbols.keys()), key=len, reverse=True)
 
     exponent = exponents_regex(lang).format(superscripts=unicode_superscript_regex())
 

--- a/quantulum3/tests/data/entities.json
+++ b/quantulum3/tests/data/entities.json
@@ -1,0 +1,6 @@
+{
+  "temperature": {
+    "dimensions": [],
+    "URI": "Temperature"
+  }
+}

--- a/quantulum3/tests/data/units.json
+++ b/quantulum3/tests/data/units.json
@@ -1,0 +1,57 @@
+{
+  "kelvin": {
+    "surfaces": [
+      "kelvin"
+    ],
+    "entity": "temperature",
+    "URI": "Kelvin",
+    "dimensions": [],
+    "symbols": [
+      "K",
+      "\u00b0K"
+    ]
+  },
+  "degree Celsius": {
+    "surfaces": [
+      "degree celsius",
+      "degree Celsius",
+      "Celsius",
+      "centigrade",
+      "degree centigrade",
+      "degree Centigrade"
+    ],
+    "entity": "temperature",
+    "URI": "Celsius",
+    "dimensions": [],
+    "symbols": [
+      "C",
+      "\u00b0C"
+    ]
+  },
+  "degree fahrenheit": {
+    "surfaces": [
+      "degree fahrenheit",
+      "Fahrenheit"
+    ],
+    "entity": "temperature",
+    "URI": "Fahrenheit",
+    "dimensions": [],
+    "symbols": [
+      "F",
+      "\u00b0F"
+    ]
+  },
+  "degree rankine": {
+    "surfaces": [
+      "degree rankine",
+      "Rankine"
+    ],
+    "entity": "temperature",
+    "URI": "Rankine_scale",
+    "dimensions": [],
+    "symbols": [
+      "\u00b0R",
+      "\u00b0Ra"
+    ]
+  }
+}

--- a/quantulum3/tests/test_classifier.py
+++ b/quantulum3/tests/test_classifier.py
@@ -55,8 +55,9 @@ class ClassifierTest(unittest.TestCase):
     """Test suite for the quantulum3 project."""
 
     def setUp(self):
-        add_type_equalities(self)
         load.clear_caches()
+        load.reset_units_and_entities_loading()
+        add_type_equalities(self)
 
     def _test_parse_classifier(self, lang="en_US", classifier_path=None):
         clf.USE_CLF = True
@@ -245,11 +246,12 @@ class ClassifierTest(unittest.TestCase):
 
             self.assertTrue(out_path.exists())
 
-    @multilang(["en_us"])
+    @multilang(["en_US"])
     def test_wikipedia_pages(self, lang):
         wikipedia.set_lang(lang[:2])
         err = []
-        for unit in load.units(lang).names.values():
+        units = dict(sorted(load.units(lang).names.items()))
+        for unit in units.values():
             try:
                 wikipedia.page(unit.uri.replace("_", " "), auto_suggest=False)
                 pass

--- a/quantulum3/tests/test_classifier.py
+++ b/quantulum3/tests/test_classifier.py
@@ -245,7 +245,6 @@ class ClassifierTest(unittest.TestCase):
             self.assertTrue(out_path.exists())
 
     @multilang(["en_us"])
-    @unittest.skip("Very slow")
     def test_wikipedia_pages(self, lang):
         wikipedia.set_lang(lang[:2])
         err = []

--- a/quantulum3/tests/test_classifier.py
+++ b/quantulum3/tests/test_classifier.py
@@ -56,6 +56,7 @@ class ClassifierTest(unittest.TestCase):
 
     def setUp(self):
         add_type_equalities(self)
+        load.clear_caches()
 
     def _test_parse_classifier(self, lang="en_US", classifier_path=None):
         clf.USE_CLF = True

--- a/quantulum3/tests/test_classifier.py
+++ b/quantulum3/tests/test_classifier.py
@@ -260,7 +260,6 @@ class ClassifierTest(unittest.TestCase):
         if err:  # pragma: no cover
             self.fail("Problematic pages:\n{}".format("\n".join(str(e) for e in err)))
 
-    # pragma: no cover
     def mock_assert_arg_in_all_calls(
         self, mock: MagicMock, arg_name: str, arg_position: int, arg_value: Any
     ):
@@ -276,6 +275,7 @@ class ClassifierTest(unittest.TestCase):
             msg=f"Expected {arg_name}={arg_value} in all calls to {mock}, but there were no calls.",
         )
 
+        # pragma: no cover
         for call in mock.call_args_list:
             try:
                 if arg_name in call.kwargs:

--- a/quantulum3/tests/test_classifier.py
+++ b/quantulum3/tests/test_classifier.py
@@ -13,7 +13,8 @@ import unittest
 import urllib.request
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import joblib
 import wikipedia
@@ -23,6 +24,9 @@ from .. import language, load
 from .. import parser as p
 from .test_setup import (
     add_type_equalities,
+    get_classifier_path,
+    get_entity_paths,
+    get_unit_paths,
     load_error_tests,
     load_expand_tests,
     load_quantity_tests,
@@ -33,10 +37,6 @@ COLOR1 = "\033[94m%s\033[0m"
 COLOR2 = "\033[91m%s\033[0m"
 TOPDIR = os.path.dirname(__file__) or "."
 TEST_DATA_DIR = Path(TOPDIR) / "data"
-
-
-def get_classifier_path(lang) -> Path:
-    return Path(TOPDIR).parent / "_lang" / lang / "clf.joblib"
 
 
 ###############################################################################
@@ -60,12 +60,12 @@ class ClassifierTest(unittest.TestCase):
     def _test_parse_classifier(self, lang="en_US", classifier_path=None):
         clf.USE_CLF = True
 
+        parse_kwargs = {"lang": lang, "classifier_path": classifier_path}
+
         all_tests = load_quantity_tests(False, lang=lang)
         for test in sorted(all_tests, key=lambda x: len(x["req"])):
             with self.subTest(input=test["req"]):
-                quants = p.parse(
-                    test["req"], lang=lang, classifier_path=classifier_path
-                )
+                quants = p.parse(test["req"], **parse_kwargs)
 
                 self.assertEqual(
                     len(test["res"]),
@@ -83,7 +83,7 @@ class ClassifierTest(unittest.TestCase):
         total = len(classifier_tests)
         error = []
         for test in sorted(classifier_tests, key=lambda x: len(x["req"])):
-            quants = p.parse(test["req"], lang=lang, classifier_path=classifier_path)
+            quants = p.parse(test["req"], **parse_kwargs)
             if quants == test["res"]:
                 correct += 1
             else:
@@ -107,7 +107,6 @@ class ClassifierTest(unittest.TestCase):
     # @multilang
     # this was causing the test to fail, `en_US` got convereted to lowercase
     # and the path was not found
-    @unittest.skipIf(sys.version_info < (3, 8), "requires python3.8 or higher")
     def test_parse_classifier_custom_classifier(self):
         """Test parsing with a custom classifier model. Use the same model as
         the default one, but load it via the classifier_path argument, and ensure
@@ -125,22 +124,48 @@ class ClassifierTest(unittest.TestCase):
             classifier_path=classifier_path,
         )
 
-        if sys.version_info <= (3, 8):  # pragma: no cover
-            # call.args and call.kwargs have different behavior pre-3.8
-            # not interested in working this out for 3.6/3.7 which are EOL or soon to be
+        # call.args and call.kwargs have different behavior pre-3.8
+        # not interested in working this out for 3.6/3.7 which are EOL or soon to be
+        if sys.version_info > (3, 7):  # pragma: no cover
             with patch(
                 "quantulum3.classifier.classifier", return_value=classifier
             ) as mock_clf_classifier:
                 self._test_parse_classifier(classifier_path=classifier_path)
 
-                # check that every call to classifier.classifier is called with the custom
-                # classifier path
-                for call in mock_clf_classifier.call_args_list:
-                    assert (
-                        "classifier_path" in call.kwargs or classifier_path in call.args
-                    ), "classifier_path not found in call args"
+                self.mock_assert_arg_in_all_calls(
+                    mock_clf_classifier,
+                    "classifier_path",
+                    1,
+                    classifier_path,
+                )
         else:  # pragma: no cover
             self._test_parse_classifier(classifier_path=classifier_path)
+
+    def test_parse_classifier_custom_units(self):
+        """Test parsing with custom units. Use the same unit files as the default ones,
+        but load them via the custom_units argument, and ensure that the results are the
+        same."""
+
+        lang = "en_US"
+        load.load_custom_units(get_unit_paths(lang), use_additional_units=False)
+        self.assertFalse(load.USE_GENERAL_UNITS)
+        self.assertFalse(load.USE_LANGUAGE_UNITS)
+        self.assertFalse(load.USE_ADDITIONAL_UNITS)
+        self.assertTrue(load.USE_CUSTOM_UNITS)
+        self._test_parse_classifier(lang=lang)
+
+    def test_parse_classifier_custom_entities(self):
+        """Test parsing with custom entities. Use the same entity files as the default ones,
+        but load them via the custom_entities argument, and ensure that the results are the
+        same."""
+
+        lang = "en_US"
+        load.load_custom_entities(get_entity_paths(lang), use_additional_entities=False)
+        self.assertFalse(load.USE_GENERAL_ENTITIES)
+        self.assertFalse(load.USE_LANGUAGE_ENTITIES)
+        self.assertFalse(load.USE_ADDITIONAL_ENTITIES)
+        self.assertTrue(load.USE_CUSTOM_ENTITIES)
+        self._test_parse_classifier(lang=lang)
 
     @multilang
     def test_expand(self, lang="en_US"):
@@ -184,22 +209,6 @@ class ClassifierTest(unittest.TestCase):
             ),
         )
 
-    def test_classifier_default_model(self, lang="en_US"):
-        """
-        Test that a classifier can be initialized with the default model
-        """
-        clf.Classifier(lang=lang)
-
-    @patch("quantulum3.language")
-    def test_classifier_custom_model(self, mock_language):
-        """
-        Test that a classifier can be initialized with a custom model
-        """
-
-        classifier_path = get_classifier_path("en_US")
-        clf.Classifier(classifier_path=classifier_path)
-        mock_language.topdir.assert_not_called()
-
     @multilang
     def test_training(self, lang="en_US"):
         """Test that classifier training works"""
@@ -236,6 +245,7 @@ class ClassifierTest(unittest.TestCase):
             self.assertTrue(out_path.exists())
 
     @multilang(["en_us"])
+    @unittest.skip("Very slow")
     def test_wikipedia_pages(self, lang):
         wikipedia.set_lang(lang[:2])
         err = []
@@ -250,6 +260,38 @@ class ClassifierTest(unittest.TestCase):
                 err.append((unit, e))
         if err:  # pragma: no cover
             self.fail("Problematic pages:\n{}".format("\n".join(str(e) for e in err)))
+
+    # pragma: no cover
+    def mock_assert_arg_in_all_calls(
+        self, mock: MagicMock, arg_name: str, arg_position: int, arg_value: Any
+    ):
+        """
+        Checks that the given arg_name/arg_value is in every call to the given mock,
+        either as a kwarg or as a positional argument.
+        """
+        trues = []
+
+        self.assertGreater(
+            len(mock.call_args_list),
+            0,
+            msg=f"Expected {arg_name}={arg_value} in all calls to {mock}, but there were no calls.",
+        )
+
+        for call in mock.call_args_list:
+            try:
+                if arg_name in call.kwargs:
+                    if call.kwargs[arg_name] == arg_value:
+                        trues.append(call)
+                elif arg_value == call.args[arg_position]:
+                    trues.append(call)
+            except IndexError:
+                pass
+
+        self.assertEqual(
+            len(trues),
+            len(mock.call_args_list),
+            msg=f"Expected {arg_name}={arg_value} in all calls to {mock}, but it was not in {len(mock.call_args_list) - len(trues)} calls.",
+        )
 
 
 ###############################################################################

--- a/quantulum3/tests/test_classifier.py
+++ b/quantulum3/tests/test_classifier.py
@@ -56,7 +56,7 @@ class ClassifierTest(unittest.TestCase):
 
     def setUp(self):
         load.clear_caches()
-        load.reset_units_and_entities_loading()
+        load.reset_quantities()
         add_type_equalities(self)
 
     def _test_parse_classifier(self, lang="en_US", classifier_path=None):

--- a/quantulum3/tests/test_classifier.py
+++ b/quantulum3/tests/test_classifier.py
@@ -278,15 +278,14 @@ class ClassifierTest(unittest.TestCase):
             msg=f"Expected {arg_name}={arg_value} in all calls to {mock}, but there were no calls.",
         )
 
-        # pragma: no cover
         for call in mock.call_args_list:
             try:
                 if arg_name in call.kwargs:
-                    if call.kwargs[arg_name] == arg_value:
+                    if call.kwargs[arg_name] == arg_value:  # pragma: no cover
                         trues.append(call)
                 elif arg_value == call.args[arg_position]:
                     trues.append(call)
-            except IndexError:
+            except IndexError:  # pragma: no cover
                 pass
 
         self.assertEqual(

--- a/quantulum3/tests/test_classifier.py
+++ b/quantulum3/tests/test_classifier.py
@@ -126,7 +126,7 @@ class ClassifierTest(unittest.TestCase):
 
         # call.args and call.kwargs have different behavior pre-3.8
         # not interested in working this out for 3.6/3.7 which are EOL or soon to be
-        if sys.version_info > (3, 7):  # pragma: no cover
+        if sys.version_info >= (3, 8):  # pragma: no cover
             with patch(
                 "quantulum3.classifier.classifier", return_value=classifier
             ) as mock_clf_classifier:

--- a/quantulum3/tests/test_load.py
+++ b/quantulum3/tests/test_load.py
@@ -35,6 +35,7 @@ def _test_function(*args, **kwargs):
     return args, kwargs
 
 
+# pylint: disable=ignore-no-self-use
 class TestCached(unittest.TestCase):
     def setUp(self) -> None:
         clear_cache()

--- a/quantulum3/tests/test_load.py
+++ b/quantulum3/tests/test_load.py
@@ -1,9 +1,33 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
-from quantulum3.load import _CACHE_DICT, cached, clear_cache
+from quantulum3 import classifier as clf
+from quantulum3 import load
+from quantulum3.load import (
+    _CACHE_DICT,
+    _CACHED_ENTITIES,
+    _CACHED_UNITS,
+    Entities,
+    Units,
+    cached,
+    clear_cache,
+    clear_entities_cache,
+    clear_units_cache,
+    entities,
+    load_custom_entities,
+    load_custom_units,
+    units,
+)
+
+from .test_setup import get_classifier_path, multilang
+
+TOPDIR = os.path.dirname(__file__) or "."
+TEST_DATA_DIR = Path(TOPDIR) / "data"
 
 
 @cached
@@ -67,9 +91,97 @@ class TestCached(unittest.TestCase):
         self.assertNotEqual(result, cached_result)
 
     def test_cached_with_path(self):
-        from pathlib import Path
-
         self._test_cached(_test_function, Path("a"))
+
+
+class TestLoaders(unittest.TestCase):
+    def setUp(self) -> None:
+        load.USE_CUSTOM_UNITS = False
+        load.USE_CUSTOM_ENTITIES = False
+        load.USE_GENERAL_UNITS = True
+        load.USE_LANGUAGE_UNITS = True
+        load.USE_LANGUAGE_ENTITIES = True
+        load.USE_ADDITIONAL_UNITS = True
+        load.USE_ADDITIONAL_ENTITIES = True
+
+        clear_cache()
+        clear_units_cache()
+        clear_entities_cache()
+
+    @multilang
+    def test_classifier_default_model(self, lang="en_US"):
+        """
+        Test that a classifier can be initialized with the default model
+        """
+        clf.Classifier(lang=lang)
+
+    @patch("quantulum3.language")
+    def test_classifier_custom_model(self, mock_language):
+        """
+        Test that a classifier can be initialized with a custom model
+        """
+
+        classifier_path = get_classifier_path("en_US")
+        clf.Classifier(classifier_path=classifier_path)
+        mock_language.topdir.assert_not_called()
+
+    @multilang
+    def test_load_units(self, lang="en_US"):
+        """
+        Test that the units can be loaded.
+        """
+        self.assertIsInstance(units(lang=lang), Units)
+
+    @multilang
+    def test_load_entities(self, lang="en_US"):
+        """
+        Test that the entities can be loaded.
+        """
+        self.assertIsInstance(entities(lang=lang), Entities)
+
+    def test_load_custom_entities(self):
+        """
+        Test that the entities can be loaded with a custom path.
+        """
+
+        custom_entities = TEST_DATA_DIR / "entities.json"
+        lang = "en_US"
+
+        load_custom_entities(custom_entities)
+        self.assertIsInstance(entities(lang=lang), Entities)
+        self.assertFalse(load.USE_GENERAL_ENTITIES)
+        self.assertFalse(load.USE_LANGUAGE_ENTITIES)
+        self.assertTrue(load.USE_ADDITIONAL_ENTITIES)
+        self.assertEqual(len(_CACHED_ENTITIES), 1)
+
+        # check caching
+        entities(lang=lang)
+        self.assertEqual(len(_CACHED_ENTITIES), 1)
+
+        # check cache updates with global variable change
+        load.USE_GENERAL_ENTITIES = True
+        entities(lang=lang)
+        self.assertEqual(len(_CACHED_ENTITIES), 2)
+
+    def test_load_custom_units(self):
+        """
+        Test that the units can be loaded with a custom path.
+        """
+        custom_unites = TEST_DATA_DIR / "units.json"
+        lang = "en_US"
+
+        load_custom_units(custom_unites)
+        self.assertIsInstance(units(lang=lang), Units)
+        self.assertEqual(len(_CACHED_UNITS), 1)
+
+        # check caching
+        units(lang=lang)
+        self.assertEqual(len(_CACHED_UNITS), 1)
+
+        # check cache updates with global variable change
+        load.USE_GENERAL_UNITS = True
+        units(lang=lang)
+        self.assertEqual(len(_CACHED_UNITS), 2)
 
 
 ###############################################################################

--- a/quantulum3/tests/test_load.py
+++ b/quantulum3/tests/test_load.py
@@ -94,6 +94,7 @@ class TestCached(unittest.TestCase):
         self._test_cached(_test_function, Path("a"))
 
 
+# pylint: disable=ignore-no-self-use
 class TestLoaders(unittest.TestCase):
     def setUp(self) -> None:
         load.USE_CUSTOM_UNITS = False

--- a/quantulum3/tests/test_load.py
+++ b/quantulum3/tests/test_load.py
@@ -12,6 +12,7 @@ from quantulum3.load import (
     _CACHE_DICT,
     _CACHED_ENTITIES,
     _CACHED_UNITS,
+    CustomQuantities,
     Entities,
     Units,
     cached,
@@ -184,6 +185,50 @@ class TestLoaders(unittest.TestCase):
         load.USE_GENERAL_UNITS = True
         units(lang=lang)
         self.assertEqual(len(_CACHED_UNITS), 2)
+
+    def test_custom_quantities(self):
+        """
+        Test custom units and entities are loaded via the context manager.
+        """
+        custom_units_path = TEST_DATA_DIR / "units.json"
+        custom_entities_path = TEST_DATA_DIR / "entities.json"
+
+        # current state
+        general_units = load.USE_GENERAL_UNITS
+        general_entities = load.USE_GENERAL_ENTITIES
+        language_units = load.USE_LANGUAGE_UNITS
+        language_entities = load.USE_LANGUAGE_ENTITIES
+        additional_units = load.USE_ADDITIONAL_UNITS
+        additional_entities = load.USE_ADDITIONAL_ENTITIES
+        custom_entities = load.USE_CUSTOM_ENTITIES
+        custom_units = load.USE_CUSTOM_UNITS
+
+        with CustomQuantities(custom_units_path, custom_entities_path):
+            self.assertIsInstance(units(), Units)
+            self.assertIsInstance(entities(), Entities)
+
+            # check default behaviour
+            assert load.USE_CUSTOM_UNITS == True
+            assert load.USE_CUSTOM_ENTITIES == True
+            assert load.USE_GENERAL_UNITS == False
+            assert load.USE_GENERAL_ENTITIES == False
+            assert load.USE_LANGUAGE_UNITS == False
+            assert load.USE_LANGUAGE_ENTITIES == False
+            assert load.USE_ADDITIONAL_UNITS == True
+            assert load.USE_ADDITIONAL_ENTITIES == True
+
+        # check that the state is restored
+        assert load.USE_GENERAL_UNITS == general_units
+        assert load.USE_GENERAL_ENTITIES == general_entities
+        assert load.USE_LANGUAGE_UNITS == language_units
+        assert load.USE_LANGUAGE_ENTITIES == language_entities
+        assert load.USE_ADDITIONAL_UNITS == additional_units
+        assert load.USE_ADDITIONAL_ENTITIES == additional_entities
+        assert load.USE_CUSTOM_UNITS == custom_units
+        assert load.USE_CUSTOM_ENTITIES == custom_entities
+
+        self.assertIsInstance(units(), Units)
+        self.assertIsInstance(entities(), Entities)
 
 
 ###############################################################################

--- a/quantulum3/tests/test_load.py
+++ b/quantulum3/tests/test_load.py
@@ -95,7 +95,7 @@ class TestCached(unittest.TestCase):
         self._test_cached(_test_function, Path("a"))
 
 
-# pylint: disable=ignore-no-self-use
+# pylint: disable=no-self-use
 class TestLoaders(unittest.TestCase):
     def setUp(self) -> None:
         load.USE_CUSTOM_UNITS = False

--- a/quantulum3/tests/test_load.py
+++ b/quantulum3/tests/test_load.py
@@ -35,7 +35,7 @@ def _test_function(*args, **kwargs):
     return args, kwargs
 
 
-# pylint: disable=ignore-no-self-use
+# pylint: disable=no-self-use
 class TestCached(unittest.TestCase):
     def setUp(self) -> None:
         clear_cache()

--- a/quantulum3/tests/test_setup.py
+++ b/quantulum3/tests/test_setup.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import unittest
+from pathlib import Path
 from typing import Dict, List
 
 from .. import classes as cls
@@ -23,6 +24,37 @@ except ImportError:
 COLOR1 = "\033[94m%s\033[0m"
 COLOR2 = "\033[91m%s\033[0m"
 TOPDIR = os.path.dirname(__file__) or "."
+
+
+def get_classifier_path(lang) -> Path:
+    return Path(TOPDIR).parent / "_lang" / lang / "clf.joblib"
+
+
+def get_unit_entity_paths(unit_entity: str, lang: str) -> List[Path]:
+    """
+    Get the paths to the unit or entity files for a given language
+
+    Parameters
+    ----------
+    unit_entity : str
+        "units" or "entities"
+    lang : str
+        Language code
+    """
+    paths: List[Path] = [
+        Path(TOPDIR).parent / "_lang" / lang / f"{unit_entity}.json",
+        Path(TOPDIR).parent / f"{unit_entity}.json",
+    ]
+
+    return [path for path in paths if path.exists()]
+
+
+def get_unit_paths(lang) -> List[Path]:
+    return get_unit_entity_paths("units", lang)
+
+
+def get_entity_paths(lang) -> List[Path]:
+    return get_unit_entity_paths("entities", lang)
 
 
 def multilang(funct_or_langs):
@@ -245,6 +277,7 @@ class SetupTest(unittest.TestCase):
 
     def setUp(self):
         add_type_equalities(self)
+        load.clear_caches()
 
     @multilang
     def test_load_tests(self, lang="en_US"):
@@ -283,6 +316,7 @@ class SetupTest(unittest.TestCase):
     def test_custom_unit(self):
         """Test if custom units work"""
         load.add_custom_unit(name="schlurp", surfaces=["slp"], entity="dimensionless")
+        self.assertTrue(load.USE_ADDITIONAL_UNITS)
         r = p.parse("This extremely sharp tool is precise up to 0.5 slp")
         self.assertEqual(
             r[0].unit.name, "schlurp", "Custom unit was not added correctly"
@@ -300,6 +334,7 @@ class SetupTest(unittest.TestCase):
         load.add_custom_unit(
             name="schlurp", surfaces=["slp"], entity="crazy new test entity"
         )
+        self.assertTrue(load.USE_ADDITIONAL_ENTITIES)
         p.parse("This extremely sharp tool is precise up to 0.5 slp")
         # would throw an error when trying to create the custom unit
 


### PR DESCRIPTION
Aims to resolve #217 

Builds on the custom classifier branch and adds functions to add custom units and entity files.

My first approach was to be the same as the custom classifier model and pass it in through the parser.parse() function, but calls to units() and entities() came from so many places and touched so much code I couldn't get it working.

Instead, we have functions in the load module to load in files./dicts which set flags to determine what gets loaded in entities() and units().